### PR TITLE
Add basic QR link shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # QRickLinks
+
+QRickLinks is a simple URL shortening service that generates short, memorable slugs in the form `adjective.adjective.noun` and creates corresponding QR codes. Users can register, log in, create short links, and view statistics about link visits.
+
+## Features
+
+- User registration and authentication
+- Short URL generation with random word combinations
+- Automatic QR code creation for each short URL
+- Dashboard listing a user's links and visit counts
+- Basic visit tracking (IP address and referrer)
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Visit `http://localhost:5000` in your browser.
+
+## Notes
+
+This project uses SQLite for simplicity and stores generated QR codes in `static/qr/`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,206 @@
+import os
+import random
+from datetime import datetime
+
+from flask import Flask, render_template, redirect, url_for, request, flash, send_from_directory
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager, login_user, login_required, logout_user, current_user, UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+import qrcode
+
+# Initialize Flask app and database
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'change-this-secret-key'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///qricklinks.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
+
+# ----------------------------
+# Database Models
+# ----------------------------
+class User(UserMixin, db.Model):
+    """Stores registered users."""
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    links = db.relationship('Link', backref='owner', lazy=True)
+
+    def set_password(self, password: str) -> None:
+        """Hash and store the user's password."""
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        """Verify a password against the stored hash."""
+        return check_password_hash(self.password_hash, password)
+
+
+class Link(db.Model):
+    """Represents a shortened link with tracking information."""
+    id = db.Column(db.Integer, primary_key=True)
+    slug = db.Column(db.String(64), unique=True, nullable=False)
+    original_url = db.Column(db.String(2048), nullable=False)
+    qr_filename = db.Column(db.String(128), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    visit_count = db.Column(db.Integer, default=0)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    visits = db.relationship('Visit', backref='link', lazy=True)
+
+
+class Visit(db.Model):
+    """Stores individual visit records for links."""
+    id = db.Column(db.Integer, primary_key=True)
+    link_id = db.Column(db.Integer, db.ForeignKey('link.id'), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    ip = db.Column(db.String(100))
+    referrer = db.Column(db.String(2048))
+
+
+@login_manager.user_loader
+def load_user(user_id: str):
+    """Flask-Login user loader callback."""
+    return User.query.get(int(user_id))
+
+
+# ----------------------------
+# Utility functions
+# ----------------------------
+ADJECTIVES = [
+    'silent', 'quick', 'bright', 'lazy', 'happy', 'brave', 'calm', 'eager',
+    'fancy', 'gentle', 'jolly', 'kind', 'lucky', 'merry', 'nice', 'proud'
+]
+NOUNS = [
+    'tiger', 'river', 'mountain', 'sky', 'ocean', 'forest', 'panda', 'lion',
+    'eagle', 'whale', 'wolf', 'falcon', 'shark', 'koala', 'leopard', 'otter'
+]
+
+
+def generate_words() -> str:
+    """Generate a random 'adjective.adjective.noun' slug."""
+    first_adj = random.choice(ADJECTIVES)
+    second_adj = random.choice(ADJECTIVES)
+    noun = random.choice(NOUNS)
+    return f"{first_adj}.{second_adj}.{noun}"
+
+
+def create_qr_code(url: str, slug: str) -> str:
+    """Generate QR code image and return filename."""
+    qr = qrcode.QRCode(box_size=10, border=4)
+    qr.add_data(url)
+    qr.make(fit=True)
+    img = qr.make_image(fill='black', back_color='white')
+    filename = f"{slug}.png"
+    filepath = os.path.join('static', 'qr', filename)
+    img.save(filepath)
+    return filename
+
+
+# ----------------------------
+# Routes
+# ----------------------------
+@app.route('/')
+@login_required
+def index():
+    """Show dashboard with user's links."""
+    links = Link.query.filter_by(owner=current_user).all()
+    return render_template('dashboard.html', links=links)
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    """User registration page."""
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            flash('Username already exists')
+            return redirect(url_for('register'))
+        user = User(username=username)
+        user.set_password(password)
+        db.session.add(user)
+        db.session.commit()
+        flash('Registration successful. Please log in.')
+        return redirect(url_for('login'))
+    return render_template('register.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    """User login page."""
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    """Log the current user out."""
+    logout_user()
+    return redirect(url_for('login'))
+
+
+@app.route('/create', methods=['POST'])
+@login_required
+def create_link():
+    """Create a shortened link and corresponding QR code."""
+    original_url = request.form['original_url']
+    slug = generate_words()
+
+    # Ensure slug is unique; regenerate if collision occurs
+    while Link.query.filter_by(slug=slug).first() is not None:
+        slug = generate_words()
+
+    short_url = url_for('redirect_link', slug=slug, _external=True)
+    qr_filename = create_qr_code(short_url, slug)
+
+    link = Link(
+        slug=slug,
+        original_url=original_url,
+        qr_filename=qr_filename,
+        owner=current_user
+    )
+    db.session.add(link)
+    db.session.commit()
+    flash('Short link created!')
+    return redirect(url_for('index'))
+
+
+@app.route('/qr/<filename>')
+def serve_qr(filename):
+    """Serve generated QR code images."""
+    return send_from_directory(os.path.join('static', 'qr'), filename)
+
+
+@app.route('/<slug>')
+def redirect_link(slug: str):
+    """Redirect to the original URL and record visit information."""
+    link = Link.query.filter_by(slug=slug).first_or_404()
+    link.visit_count += 1
+
+    visit = Visit(
+        link=link,
+        ip=request.remote_addr,
+        referrer=request.referrer
+    )
+    db.session.add(visit)
+    db.session.commit()
+    return redirect(link.original_url)
+
+
+if __name__ == '__main__':
+    # Create database tables if they don't exist
+    if not os.path.exists('qricklinks.db'):
+        # SQLAlchemy operations need an application context
+        with app.app_context():
+            db.create_all()
+    # Run the Flask development server
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+Flask-Login
+Flask-SQLAlchemy
+qrcode
+Pillow

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>QRickLinks</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">QRickLinks</a>
+    <div class="d-flex">
+      {% if current_user.is_authenticated %}
+      <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>
+      <a class="btn btn-outline-secondary" href="{{ url_for('logout') }}">Logout</a>
+      {% else %}
+      <a class="btn btn-outline-primary me-2" href="{{ url_for('login') }}">Login</a>
+      <a class="btn btn-primary" href="{{ url_for('register') }}">Register</a>
+      {% endif %}
+    </div>
+  </div>
+</nav>
+<div class="container">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-info">
+        {{ messages[0] }}
+      </div>
+    {% endif %}
+  {% endwith %}
+
+  {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Create new link</h2>
+<form method="post" action="{{ url_for('create_link') }}">
+  <div class="mb-3">
+    <label for="original_url" class="form-label">Long URL</label>
+    <input type="url" class="form-control" id="original_url" name="original_url" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Shorten</button>
+</form>
+
+<hr>
+<h2>Your links</h2>
+<table class="table table-striped">
+  <thead>
+    <tr><th>Slug</th><th>Original URL</th><th>QR Code</th><th>Visits</th></tr>
+  </thead>
+  <tbody>
+    {% for link in links %}
+    <tr>
+      <td>{{ link.slug }}</td>
+      <td><a href="{{ link.original_url }}" target="_blank">{{ link.original_url }}</a></td>
+      <td><img src="{{ url_for('serve_qr', filename=link.qr_filename) }}" width="100"></td>
+      <td>{{ link.visit_count }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Register</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a Flask app for creating short links with QR codes
- add random adjective.adjective.noun slug generation
- store links and visits in SQLite via SQLAlchemy
- provide user registration and login
- serve QR codes and track visits
- add HTML templates for basic UI
- document setup steps

## Testing
- `python -m py_compile app.py`
- `python app.py` *(server started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6884a3f6b9808328b4a298f1d86ea3d5