### PR TITLE
Implement admin backend with dashboard and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
 - Automatic QR code creation for each short URL
 - Dashboard listing a user's links and visit counts
 - Basic visit tracking (IP address and referrer)
+- Admin dashboard with site statistics and settings
 
 ## Setup
 
@@ -21,6 +22,15 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
    python app.py
    ```
 3. Visit `http://localhost:5000` in your browser.
+
+### Admin Access
+
+An administrator account is created automatically with the following credentials:
+
+* **Username:** `philadmin`
+* **Password:** `Admin12345`
+
+Log in at `http://localhost:5000/admin/login` to view site statistics and manage settings such as the base URL used for generated links.
 
 ## Notes
 

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>QRickLinks Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('admin_dashboard') }}">Admin Dashboard</a>
+    <div class="d-flex">
+      <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>
+      <a class="btn btn-outline-secondary" href="{{ url_for('admin_logout') }}">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-info">
+        {{ messages[0] }}
+      </div>
+    {% endif %}
+  {% endwith %}
+
+  {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1,0 +1,10 @@
+{% extends 'admin_base.html' %}
+{% block content %}
+<h2>Site Summary</h2>
+<ul>
+  <li>Total Users: {{ user_count }}</li>
+  <li>Total Links: {{ link_count }}</li>
+  <li>Total Clicks: {{ total_clicks }}</li>
+</ul>
+<a class="btn btn-primary" href="{{ url_for('admin_settings') }}">Edit Settings</a>
+{% endblock %}

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Admin Login</h2>
+<form method="post">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -1,0 +1,11 @@
+{% extends 'admin_base.html' %}
+{% block content %}
+<h2>Global Settings</h2>
+<form method="post">
+  <div class="mb-3">
+    <label for="base_url" class="form-label">Base URL</label>
+    <input type="url" class="form-control" id="base_url" name="base_url" value="{{ settings.base_url }}" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add admin-only login with dashboard showing counts
- allow admin to change base URL via settings model
- store admin credentials automatically on startup
- update README with admin instructions
- add HTML templates for admin pages

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6884b17a336c8328929a79d78b74b900