### PR TITLE
Add QR customization with download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
 - Automatic QR code creation for each short URL
 - Dashboard listing a user's links and visit counts
 - Basic visit tracking (IP address and referrer)
+- Customizable QR codes (colors, size, rounded modules, error correction and center logos)
+- Downloadable QR images
 
 ## Setup
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,10 +1,49 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Create new link</h2>
-<form method="post" action="{{ url_for('create_link') }}">
+<form method="post" action="{{ url_for('create_link') }}" enctype="multipart/form-data">
   <div class="mb-3">
     <label for="original_url" class="form-label">Long URL</label>
     <input type="url" class="form-control" id="original_url" name="original_url" required>
+  </div>
+  <div class="row">
+    <div class="col-md-3 mb-3">
+      <label class="form-label" for="fill_color">QR Color</label>
+      <input type="color" class="form-control form-control-color" id="fill_color" name="fill_color" value="#000000">
+    </div>
+    <div class="col-md-3 mb-3">
+      <label class="form-label" for="back_color">Background</label>
+      <input type="color" class="form-control form-control-color" id="back_color" name="back_color" value="#ffffff">
+    </div>
+    <div class="col-md-2 mb-3">
+      <label class="form-label" for="box_size">Box Size</label>
+      <input type="number" class="form-control" id="box_size" name="box_size" value="10" min="1">
+    </div>
+    <div class="col-md-2 mb-3">
+      <label class="form-label" for="border">Border</label>
+      <input type="number" class="form-control" id="border" name="border" value="4" min="0">
+    </div>
+    <div class="col-md-2 mb-3">
+      <label class="form-label" for="error_correction">Redundancy</label>
+      <select class="form-select" id="error_correction" name="error_correction">
+        <option value="L">L</option>
+        <option value="M" selected>M</option>
+        <option value="Q">Q</option>
+        <option value="H">H</option>
+      </select>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3 mb-3">
+      <div class="form-check mt-4">
+        <input class="form-check-input" type="checkbox" id="rounded" name="rounded">
+        <label class="form-check-label" for="rounded">Rounded modules</label>
+      </div>
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label" for="logo">Center logo</label>
+      <input class="form-control" type="file" id="logo" name="logo" accept="image/*">
+    </div>
   </div>
   <button type="submit" class="btn btn-primary">Shorten</button>
 </form>
@@ -13,7 +52,13 @@
 <h2>Your links</h2>
 <table class="table table-striped">
   <thead>
-    <tr><th>Slug</th><th>Original URL</th><th>QR Code</th><th>Visits</th></tr>
+    <tr>
+      <th>Slug</th>
+      <th>Original URL</th>
+      <th>QR Code</th>
+      <th>Visits</th>
+      <th>Export</th>
+    </tr>
   </thead>
   <tbody>
     {% for link in links %}
@@ -22,6 +67,9 @@
       <td><a href="{{ link.original_url }}" target="_blank">{{ link.original_url }}</a></td>
       <td><img src="{{ url_for('serve_qr', filename=link.qr_filename) }}" width="100"></td>
       <td>{{ link.visit_count }}</td>
+      <td>
+        <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('download_qr', filename=link.qr_filename) }}">Download</a>
+      </td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- allow customizing QR codes including colors, size, border, error correction, rounded modules and optional center logo
- support downloading generated QR images
- update dashboard form with customization fields and download button
- document new features in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6884b1e7cc808328acda8680a3c068c2