### PR TITLE
Add Raspberry Pi hosting helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+instance/
+qricklinks.db
+static/qr/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the application:
+2. Run the application (optionally specify a port):
    ```bash
-   python app.py
+   ./run_on_pi.sh       # defaults to port 5000
+   ./run_on_pi.sh 8080 # run on port 8080
    ```
-3. Visit `http://localhost:5000` in your browser.
+3. Visit `http://<your-pi-ip>:<port>` in your browser.
 
 ## Notes
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import os
 import random
+import argparse
 from datetime import datetime
 
 from flask import Flask, render_template, redirect, url_for, request, flash, send_from_directory
@@ -197,10 +198,23 @@ def redirect_link(slug: str):
 
 
 if __name__ == '__main__':
+    """Entry point when running the script directly."""
+
+    # Parse optional command line argument for the port number
+    parser = argparse.ArgumentParser(description="Run the QRickLinks server")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5000,
+        help="Port to listen on (default: 5000)",
+    )
+    args = parser.parse_args()
+
     # Create database tables if they don't exist
     if not os.path.exists('qricklinks.db'):
         # SQLAlchemy operations need an application context
         with app.app_context():
             db.create_all()
-    # Run the Flask development server
-    app.run(debug=True)
+
+    # Run the Flask development server and bind to all network interfaces
+    app.run(debug=True, host='0.0.0.0', port=args.port)

--- a/run_on_pi.sh
+++ b/run_on_pi.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# QRickLinks hosting helper script for Raspberry Pi
+# Usage: ./run_on_pi.sh [PORT]
+# If PORT is omitted, the server runs on port 5000.
+
+# Read the first argument as the desired port, falling back to 5000
+PORT=${1:-5000}
+
+# Install Python dependencies listed in requirements.txt
+pip install --quiet -r requirements.txt
+
+# Start the application accessible from the network
+python app.py --port "$PORT"


### PR DESCRIPTION
## Summary
- provide run_on_pi.sh script to simplify hosting on a Raspberry Pi
- allow selecting a port via `--port` when running `app.py`
- update README with new usage instructions
- add a `.gitignore` to keep runtime artifacts out of the repo

## Testing
- `pip install --quiet -r requirements.txt`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6884b2c80abc8328af4a5814648f4564