### PR TITLE
Add Raspberry Pi run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
    ```
 3. Visit `http://localhost:5000` in your browser.
 
+### Raspberry Pi Hosting
+
+Use the provided `run_rpi.py` script to host the application on a Raspberry Pi.
+It binds to all network interfaces and accepts an optional port argument:
+
+```bash
+python run_rpi.py 8080  # runs the server on port 8080
+```
+
+Omit the argument to use the default port `5000`.
+
 ### Admin Access
 
 An administrator account is created automatically with the following credentials:

--- a/run_rpi.py
+++ b/run_rpi.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Run the QRickLinks Flask app on a Raspberry Pi.
+
+This script allows specifying the port via a command line argument so the
+application can be easily hosted on different ports without modifying the
+source code.
+
+Usage:
+    python run_rpi.py [port]
+If no port is provided, the server defaults to port 5000.
+"""
+
+import sys
+
+# Import the Flask application instance from app.py
+from app import app
+
+
+def main() -> None:
+    """Parse the optional port argument and start the server."""
+    default_port = 5000
+    port = default_port
+
+    # Attempt to read the first command line argument as the port number
+    if len(sys.argv) > 1:
+        try:
+            port = int(sys.argv[1])
+        except ValueError:
+            print(f"Invalid port '{sys.argv[1]}'. Using default {default_port}.")
+            port = default_port
+
+    # Run the Flask app on all network interfaces so it's accessible on the LAN
+    app.run(host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_rpi.py` helper script for hosting on Raspberry Pi with an optional port argument
- document Raspberry Pi hosting instructions in README

## Testing
- `python -m py_compile run_rpi.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6884ba5f9b4c83288056b593d1d8fbcc