### PR TITLE
Add customizable QR code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # QRickLinks
 
-QRickLinks is a simple URL shortening service that generates short, memorable slugs in the form `adjective.adjective.noun` and creates corresponding QR codes. Users can register, log in, create short links, and view statistics about link visits.
+QRickLinks is a simple URL shortening service that generates short, memorable slugs in the form `adjective.adjective.noun` and creates corresponding QR codes. Users can register, log in, create short links, and view statistics about link visits. The QR code generator supports extensive customisation such as colours, size, pattern style, error correction level and even embedding a central logo.
 
 ## Features
 
 - User registration and authentication
 - Short URL generation with random word combinations
 - Automatic QR code creation for each short URL
+- Customisable QR codes (colours, size, pattern, redundancy and logo)
 - Dashboard listing a user's links and visit counts
 - Basic visit tracking (IP address and referrer)
 - Admin dashboard with site statistics and settings
@@ -46,3 +47,4 @@ Log in at `http://localhost:5000/admin/login` to view site statistics and manage
 ## Notes
 
 This project uses SQLite for simplicity and stores generated QR codes in `static/qr/`.
+When creating a new link you can tailor the QR code's appearance by choosing colours, module size, border width, pattern style, error correction level and an optional logo image.

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,10 +1,49 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Create new link</h2>
-<form method="post" action="{{ url_for('create_link') }}">
+<form method="post" action="{{ url_for('create_link') }}" enctype="multipart/form-data">
   <div class="mb-3">
     <label for="original_url" class="form-label">Long URL</label>
     <input type="url" class="form-control" id="original_url" name="original_url" required>
+  </div>
+  <div class="mb-3">
+    <label for="fill_color" class="form-label">Foreground Color</label>
+    <input type="color" class="form-control form-control-color" id="fill_color" name="fill_color" value="#000000">
+  </div>
+  <div class="mb-3">
+    <label for="back_color" class="form-label">Background Color</label>
+    <input type="color" class="form-control form-control-color" id="back_color" name="back_color" value="#ffffff">
+  </div>
+  <div class="row">
+    <div class="col-md-3 mb-3">
+      <label for="box_size" class="form-label">Box Size</label>
+      <input type="number" class="form-control" id="box_size" name="box_size" value="10" min="1" max="20">
+    </div>
+    <div class="col-md-3 mb-3">
+      <label for="border" class="form-label">Border</label>
+      <input type="number" class="form-control" id="border" name="border" value="4" min="0" max="10">
+    </div>
+    <div class="col-md-3 mb-3">
+      <label for="pattern" class="form-label">Pattern</label>
+      <select id="pattern" name="pattern" class="form-select">
+        <option value="square" selected>Square</option>
+        <option value="rounded">Rounded</option>
+        <option value="circle">Circle</option>
+      </select>
+    </div>
+    <div class="col-md-3 mb-3">
+      <label for="error_correction" class="form-label">Redundancy</label>
+      <select id="error_correction" name="error_correction" class="form-select">
+        <option value="L">L</option>
+        <option value="M" selected>M</option>
+        <option value="Q">Q</option>
+        <option value="H">H</option>
+      </select>
+    </div>
+  </div>
+  <div class="mb-3">
+    <label for="logo" class="form-label">Central Logo (optional)</label>
+    <input type="file" class="form-control" id="logo" name="logo" accept="image/*">
   </div>
   <button type="submit" class="btn btn-primary">Shorten</button>
 </form>
@@ -13,7 +52,7 @@
 <h2>Your links</h2>
 <table class="table table-striped">
   <thead>
-    <tr><th>Slug</th><th>Original URL</th><th>QR Code</th><th>Visits</th></tr>
+    <tr><th>Slug</th><th>Original URL</th><th>QR Code</th><th>Visits</th><th>Download</th></tr>
   </thead>
   <tbody>
     {% for link in links %}
@@ -22,6 +61,7 @@
       <td><a href="{{ link.original_url }}" target="_blank">{{ link.original_url }}</a></td>
       <td><img src="{{ url_for('serve_qr', filename=link.qr_filename) }}" width="100"></td>
       <td>{{ link.visit_count }}</td>
+      <td><a href="{{ url_for('download_qr', filename=link.qr_filename) }}" class="btn btn-sm btn-secondary">Download</a></td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- support colours, size, pattern style, redundancy and logo in QR generation
- allow downloading generated QR codes
- document new customisation features in README

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: UNIQUE constraint failed: user.username)*

------
https://chatgpt.com/codex/tasks/task_e_6884bb673cf88328a46a38fa20b59245