### PR TITLE
Make slugs act as links with new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QRickLinks
 
-QRickLinks is a simple URL shortening service that generates short, memorable slugs in the form `adjective.adjective.noun` and creates corresponding QR codes. Users can register, log in, create short links, and view statistics about link visits. The QR code generator supports extensive customisation such as colours, size, pattern style, error correction level and even embedding a central logo.
+QRickLinks is a simple URL shortening service that generates short, memorable slugs in the form `adjective.Adjective.Noun` and creates corresponding QR codes. Users can register, log in, create short links, and view statistics about link visits. The QR code generator supports extensive customisation such as colours, size, pattern style, error correction level and even embedding a central logo.
 
 ## Features
 

--- a/app.py
+++ b/app.py
@@ -96,10 +96,15 @@ NOUNS = [
 
 
 def generate_words() -> str:
-    """Generate a random 'adjective.adjective.noun' slug."""
-    first_adj = random.choice(ADJECTIVES)
-    second_adj = random.choice(ADJECTIVES)
-    noun = random.choice(NOUNS)
+    """Generate a random slug in the form ``adjective.Adjective.Noun``."""
+
+    # Choose words from the predefined word lists. The first adjective is left
+    # lowercase while the second adjective and the noun are capitalised to
+    # match the desired pattern.
+    first_adj = random.choice(ADJECTIVES).lower()
+    second_adj = random.choice(ADJECTIVES).capitalize()
+    noun = random.choice(NOUNS).capitalize()
+
     return f"{first_adj}.{second_adj}.{noun}"
 
 
@@ -191,9 +196,15 @@ def admin_required(f):
 @app.route('/')
 @login_required
 def index():
-    """Show dashboard with user's links."""
+    """Show the dashboard listing the current user's links."""
+
     links = Link.query.filter_by(owner=current_user).all()
-    return render_template('dashboard.html', links=links)
+
+    # Pass the configured base URL so templates can construct the full short
+    # link for each slug.
+    base_url = get_settings().base_url.rstrip('/')
+
+    return render_template('dashboard.html', links=links, base_url=base_url)
 
 
 @app.route('/register', methods=['GET', 'POST'])

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -57,11 +57,19 @@
   <tbody>
     {% for link in links %}
     <tr>
-      <td>{{ link.slug }}</td>
-      <td><a href="{{ link.original_url }}" target="_blank">{{ link.original_url }}</a></td>
+      <td>
+        <a href="{{ base_url }}/{{ link.slug }}" target="_blank">{{ link.slug }}</a>
+      </td>
+      <td>
+        <a href="{{ link.original_url }}" target="_blank">{{ link.original_url }}</a>
+      </td>
       <td><img src="{{ url_for('serve_qr', filename=link.qr_filename) }}" width="100"></td>
       <td>{{ link.visit_count }}</td>
-      <td><a href="{{ url_for('download_qr', filename=link.qr_filename) }}" class="btn btn-sm btn-secondary">Download</a></td>
+      <td>
+        <a href="{{ url_for('download_qr', filename=link.qr_filename) }}" class="btn btn-sm btn-secondary">
+          Download
+        </a>
+      </td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- tweak slug generator to produce `adjective.Adjective.Noun`
- expose base URL in dashboard view
- link slugs to their short URLs in the dashboard
- update documentation

## Testing
- `python -m py_compile app.py run_rpi.py`


------
https://chatgpt.com/codex/tasks/task_e_6884ce6061a08328af68e9b0fa066455