### PR TITLE
Make slugs clickable

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,15 @@ class Link(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     visits = db.relationship('Visit', backref='link', lazy=True)
 
+    @property
+    def short_url(self) -> str:
+        """Return the public short URL for this link."""
+        # Retrieve the base URL from the settings table and strip any trailing
+        # slash so concatenation is predictable.
+        base_url = get_settings().base_url.rstrip('/')
+        # Combine base URL and slug to form the full short URL
+        return f"{base_url}/{self.slug}"
+
 
 class Visit(db.Model):
     """Stores individual visit records for links."""
@@ -203,6 +212,7 @@ def admin_required(f):
 def index():
     """Show dashboard with user's links."""
     links = Link.query.filter_by(owner=current_user).all()
+    # No additional parameters required; the template can use link.short_url
     return render_template('dashboard.html', links=links)
 
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -63,7 +63,7 @@
   <tbody>
     {% for link in links %}
     <tr>
-      <td>{{ link.slug }}</td>
+      <td><a href="{{ link.short_url }}" target="_blank">{{ link.slug }}</a></td>
       <td><a href="{{ link.original_url }}" target="_blank">{{ link.original_url }}</a></td>
       <td><img src="{{ url_for('serve_qr', filename=link.qr_filename) }}" width="100"></td>
       <td>{{ link.visit_count }}</td>


### PR DESCRIPTION
## Summary
- compute `short_url` for each link
- show slug as a clickable link on dashboard

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py run_rpi.py`


------
https://chatgpt.com/codex/tasks/task_e_6884e72bbc9483289fec8e27c3233cf8