### PR TITLE
Fix QR logo generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -146,6 +146,13 @@ def create_qr_code(
     }
     error_correction_level = ec_map.get(error_correction.upper(), qrcode.constants.ERROR_CORRECT_M)
 
+    # When embedding a logo the qrcode library requires the highest
+    # error correction level (H).  Adjust automatically so users do not
+    # encounter cryptic errors when uploading a logo with a lower level
+    # selected in the form.
+    if logo_filename and error_correction_level != qrcode.constants.ERROR_CORRECT_H:
+        error_correction_level = qrcode.constants.ERROR_CORRECT_H
+
     # Select the module drawer style used to render QR modules
     drawers = {
         "square": SquareModuleDrawer(),


### PR DESCRIPTION
## Summary
- automatically use error correction level H if a logo is supplied

## Testing
- `python - <<'PY'
from PIL import Image
img = Image.new('RGB', (50,50))
img.save('static/logos/logo.png')
from app import create_qr_code
print(create_qr_code('http://example.com', 'slugtest', logo_filename='logo.png'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6884ec9a58e483289a3f378d5c485f57