### PR TITLE
Add Windows runner script and refactor DB setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ python run_rpi.py 8080  # runs the server on port 8080
 
 Omit the argument to use the default port `5000`.
 
+### Windows Quick Start
+
+On Windows you can run `run_windows.py` which installs dependencies, prepares
+the database and starts the server. An optional port argument overrides the
+default:
+
+```bash
+python run_windows.py 5001  # starts the app on port 5001
+```
+
+Omit the argument to use port `5000`.
+
 ### Admin Access
 
 An administrator account is created automatically with the following credentials:

--- a/app.py
+++ b/app.py
@@ -457,10 +457,10 @@ def redirect_link(slug: str):
     return redirect(link.original_url)
 
 
-if __name__ == '__main__':
-    # Always run database related setup inside the application context
+def initialize_database() -> None:
+    """Create database tables and default records."""
     with app.app_context():
-        # Create tables if they do not yet exist
+        # Ensure tables exist before the server starts
         db.create_all()
 
         # ------------------------------------------------------------------
@@ -470,10 +470,8 @@ if __name__ == '__main__':
         # lack newer columns. The following check ensures the "is_admin" column
         # exists on the user table and adds it on the fly if missing. This
         # avoids manual migrations for small schema changes.
-        # Query the SQLite schema to check for the presence of the is_admin column
         columns = [row[1] for row in db.session.execute(text("PRAGMA table_info(user)")).fetchall()]
         if 'is_admin' not in columns:
-            # Add the is_admin column if missing to support admin accounts
             db.session.execute(text("ALTER TABLE user ADD COLUMN is_admin BOOLEAN DEFAULT 0"))
             db.session.commit()
 
@@ -487,5 +485,9 @@ if __name__ == '__main__':
             db.session.add(admin)
             db.session.commit()
 
+
+if __name__ == '__main__':
+    # Prepare the database and default records before starting
+    initialize_database()
     # Run the Flask development server
     app.run(debug=True)

--- a/run_rpi.py
+++ b/run_rpi.py
@@ -13,7 +13,8 @@ If no port is provided, the server defaults to port 5000.
 import sys
 
 # Import the Flask application instance from app.py
-from app import app
+# Import the Flask app and database initialization helper
+from app import app, initialize_database
 
 
 def main() -> None:
@@ -29,6 +30,8 @@ def main() -> None:
             print(f"Invalid port '{sys.argv[1]}'. Using default {default_port}.")
             port = default_port
 
+    # Prepare the database before starting
+    initialize_database()
     # Run the Flask app on all network interfaces so it's accessible on the LAN
     app.run(host="0.0.0.0", port=port)
 

--- a/run_windows.py
+++ b/run_windows.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Utility script to install dependencies and run QRickLinks on Windows.
+
+This script installs the required Python packages, prepares the database, and
+starts the Flask application on the specified port. It is intended as a
+convenient entry point when developing or running the project on Windows.
+
+Usage:
+    python run_windows.py [port]
+If no port is provided, the server defaults to 5000.
+"""
+
+import subprocess
+import sys
+
+
+def main() -> None:
+    """Install dependencies, set up the database and run the server."""
+    default_port = 5000
+    port = default_port
+
+    # Parse the optional port argument from the command line
+    if len(sys.argv) > 1:
+        try:
+            port = int(sys.argv[1])
+        except ValueError:
+            print(f"Invalid port '{sys.argv[1]}'. Using default {default_port}.")
+            port = default_port
+
+    # Install required packages using the current Python interpreter
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+
+    # Import the Flask application only after dependencies are available
+    from app import app, initialize_database
+
+    # Perform database migrations and insert default records
+    initialize_database()
+
+    # Start the Flask development server on the chosen port
+    app.run(host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- factor out database initialisation function
- run Raspberry Pi script with initialisation
- add `run_windows.py` to install dependencies and run the app on a given port
- document Windows usage in README

## Testing
- `python -m py_compile app.py run_rpi.py run_windows.py`
- `timeout 5 python run_windows.py 5001` *(fails later because process timed out but shows dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68850150e1bc8328bb0bb09aa1fe707c