### PR TITLE
Add base62 short codes alongside word slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # QRickLinks
 
-QRickLinks is a simple URL shortening service that generates short, memorable slugs in the form `adjective.adjective.noun` and creates corresponding QR codes. Users can register, log in, create short links, and view statistics about link visits. The QR code generator supports extensive customisation such as colours, size, pattern style, error correction level and even embedding a central logo.
+QRickLinks is a simple URL shortening service that generates short, memorable slugs in the form `adjective.adjective.noun` as well as a compact base&nbsp;62 code. Each link therefore has two ways to access it and a corresponding QR code. Users can register, log in, create short links, and view statistics about link visits. The QR code generator supports extensive customisation such as colours, size, pattern style, error correction level and even embedding a central logo.
 
 ## Features
 
 - User registration and authentication
 - Short URL generation with random word combinations
+- Base62 short codes generated alongside word slugs
 - Automatic QR code creation for each short URL
 - Customisable QR codes (colours, size, pattern, redundancy and logo)
 - URLs missing a scheme are automatically prefixed with `https://`

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -54,6 +54,7 @@
   <thead>
     <tr>
       <th>Slug</th>
+      <th>Code</th>
       <th>Original URL</th>
       <th>QR Code</th>
       <th>Visits</th>
@@ -64,6 +65,7 @@
     {% for link in links %}
     <tr>
       <td><a href="{{ link.short_url }}" target="_blank">{{ link.slug }}</a></td>
+      <td><a href="{{ link.code_url }}" target="_blank">{{ link.short_code }}</a></td>
       <td><a href="{{ link.original_url }}" target="_blank">{{ link.original_url }}</a></td>
       <td><img src="{{ url_for('serve_qr', filename=link.qr_filename) }}" width="100"></td>
       <td>{{ link.visit_count }}</td>
@@ -73,7 +75,7 @@
       </td>
     </tr>
     <tr class="collapse" id="c{{ link.id }}">
-      <td colspan="5">
+      <td colspan="6">
         <form method="post" action="{{ url_for('customize_link', link_id=link.id) }}" enctype="multipart/form-data" class="row g-2">
           <div class="col-md-2">
             <label for="fill_color{{ link.id }}" class="form-label">Foreground</label>


### PR DESCRIPTION
## Summary
- add a `short_code` column to store a base62 identifier
- show both the human readable slug and short code on the dashboard
- allow redirection via slug or short code
- update initialization to add missing column and backfill
- document the new short code capability

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68850b611a9c83288f9f5d3459bd7099