### PR TITLE
Fix URL input validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,8 +116,9 @@ def generate_words() -> str:
 
 def normalize_url(url: str) -> str:
     """Ensure the provided URL includes a scheme."""
-    # When users omit the protocol (e.g. 'google.com'), urlparse
-    # leaves the scheme empty. Prepend 'https://' so redirects work.
+    # urlparse will interpret "google.com" as a path with an empty scheme.
+    # To keep the client-side form flexible (it now accepts plain text),
+    # prepend "https://" when the scheme is missing so redirects work.
     if not urlparse(url).scheme:
         return f"https://{url}"
     return url

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -4,7 +4,12 @@
 <form method="post">
   <div class="mb-3">
     <label for="base_url" class="form-label">Base URL</label>
-    <input type="url" class="form-control" id="base_url" name="base_url" value="{{ settings.base_url }}" required>
+    <!--
+      Allow admins to enter the base URL without triggering the browser's
+      built-in URL validation. Any missing scheme will be handled on the
+      server side in the same way as regular links.
+    -->
+    <input type="text" class="form-control" id="base_url" name="base_url" value="{{ settings.base_url }}" required>
   </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,7 +4,13 @@
 <form method="post" action="{{ url_for('create_link') }}" enctype="multipart/form-data">
   <div class="mb-3">
     <label for="original_url" class="form-label">Long URL</label>
-    <input type="url" class="form-control" id="original_url" name="original_url" required>
+    <!--
+      Use a plain text field rather than HTML5's URL input so users can
+      enter domains without a scheme (e.g. "google.com") without the
+      browser displaying a validation error. The server will add the
+      "https://" prefix if needed.
+    -->
+    <input type="text" class="form-control" id="original_url" name="original_url" required>
   </div>
   <div class="mb-3">
     <label for="fill_color" class="form-label">Foreground Color</label>


### PR DESCRIPTION
## Summary
- allow users to enter domain names without scheme
- document URL normalisation in app.py

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68850c37300c832887a6d1af1818e47a