### PR TITLE
Add link analytics details page

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -77,6 +77,7 @@
       <td>{{ link.visit_count }}</td>
       <td>
         <a href="{{ url_for('download_qr', filename=link.qr_filename) }}" class="btn btn-sm btn-secondary mb-1">Download</a>
+        <a href="{{ url_for('link_details', link_id=link.id) }}" class="btn btn-sm btn-info mb-1">Details</a>
         <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#c{{ link.id }}" aria-expanded="false" aria-controls="c{{ link.id }}">Customize</button>
       </td>
     </tr>

--- a/templates/link_details.html
+++ b/templates/link_details.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Details for {{ link.slug }}</h2>
+<p>Total Clicks: {{ total_clicks }}</p>
+<p>
+  Unique Clicks: {{ unique_count }}
+  <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#unique" aria-expanded="false" aria-controls="unique">Show</button>
+</p>
+<div class="collapse" id="unique">
+  <ul class="list-group">
+  {% for pair, times in visit_map.items() %}
+    {% set ip = pair[0] %}
+    {% set mac = pair[1] %}
+    <li class="list-group-item">
+      <strong>{{ ip }}{% if mac %} ({{ mac }}){% endif %}</strong>
+      <ul class="mb-0">
+        {% for t in times %}
+        <li>{{ t }}</li>
+        {% endfor %}
+      </ul>
+    </li>
+  {% endfor %}
+  </ul>
+</div>
+<div id="map" style="height:400px" class="mt-3"></div>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+  const map = L.map('map').setView([0,0], 2);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19}).addTo(map);
+  const ips = {{ visit_map.keys()|list|map(attribute=0)|tojson }};
+  ips.forEach(ip => {
+    fetch('http://ip-api.com/json/' + ip)
+      .then(r => r.json())
+      .then(d => {
+        if(d.status === 'success'){
+          L.marker([d.lat, d.lon]).addTo(map).bindPopup(ip);
+        }
+      });
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- store MAC addresses for visits
- implement link details route for viewing analytics
- provide a new Details button on the dashboard
- display click statistics and map pins of visitor IPs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68851e3f93f88328a26188b436397e36