### PR TITLE
Improve rounded QR code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ Log in at `http://localhost:5000/admin/login` to view site statistics and manage
 This project uses SQLite for simplicity and stores generated QR codes in `static/qr/`.
 After a link is created you can customise its QR code from a pull-down menu next to the entry on your dashboard. Options include colours, module size, border width, pattern style, error correction level and an optional central logo.
 
-The *rounded* pattern now applies a smaller corner radius so its curved edges are easier to distinguish from the default square modules.
+The *rounded* pattern now uses a radius ratio of `1` so every module is drawn as
+a circle, providing a clear visual distinction from the default square style.

--- a/app.py
+++ b/app.py
@@ -178,10 +178,11 @@ def create_qr_code(
     # Select the module drawer style used to render QR modules
     drawers = {
         "square": SquareModuleDrawer(),
-        # Use a smaller radius to make rounded modules visually distinct from
-        # squares.  A ratio of 0.25 produces gentle curves that stand out even
-        # when neighbouring modules touch.
-        "rounded": RoundedModuleDrawer(radius_ratio=0.25),
+        # A radius ratio of 1 draws each module as a circle, producing a
+        # noticeably different look from the default square modules.
+        # RoundedModuleDrawer considers neighbouring modules when applying the
+        # curvature so connected modules blend together cleanly.
+        "rounded": RoundedModuleDrawer(radius_ratio=1),
         "circle": CircleModuleDrawer(),
     }
     # Fallback to a square pattern if an unknown option is provided


### PR DESCRIPTION
## Summary
- make the `rounded` pattern fully circular using `RoundedModuleDrawer(radius_ratio=1)`
- update README notes about rounded pattern

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68851e5bb8a88328b1d7b5709869da75