### PR TITLE
Fix details page JSON rendering

### DIFF
--- a/templates/link_details.html
+++ b/templates/link_details.html
@@ -28,7 +28,12 @@
 <script>
   const map = L.map('map').setView([0,0], 2);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19}).addTo(map);
-  const ips = {{ visit_map.keys()|list|map(attribute=0)|tojson }};
+  {#
+    Convert map keys to a list of IPs for JSON serialisation. The map filter
+    returns a generator, so apply the list filter after mapping to materialise
+    the sequence before passing it to the tojson filter.
+  #}
+  const ips = {{ visit_map.keys()|map(attribute=0)|list|tojson }};
   ips.forEach(ip => {
     fetch('http://ip-api.com/json/' + ip)
       .then(r => r.json())


### PR DESCRIPTION
## Summary
- fix JSON serialization error on details page

## Testing
- `python - <<'EOF'
from app import app, db, initialize_database, User, Link
app.config['TESTING'] = True
initialize_database()
client = app.test_client()
with app.app_context():
    user = User(username='demo'); user.set_password('demo'); db.session.add(user); db.session.commit()
    client.post('/login', data={'username':'demo','password':'demo'}, follow_redirects=True)
    client.post('/create', data={'original_url':'https://example.com'}, follow_redirects=True)
    link = Link.query.filter_by(owner=user).first()
    resp = client.get(f'/details/{link.id}', follow_redirects=True)
    print('details page status:', resp.status)
EOF

------
https://chatgpt.com/codex/tasks/task_e_6885229cb23c83289a97ca880b5e0b04