### PR TITLE
Simplify dashboard link creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
 - Base62 short codes generated alongside word slugs
 - Automatic QR code creation for each short URL (the QR code embeds the
   compact base62 link)
-- Customisable QR codes (colours, size, pattern, redundancy and logo)
+- QR codes can be customised after creation from the dashboard
 - URLs missing a scheme are automatically prefixed with `https://`
 - Dashboard listing a user's links and visit counts
 - Basic visit tracking (IP address and referrer)
@@ -62,7 +62,7 @@ Log in at `http://localhost:5000/admin/login` to view site statistics and manage
 ## Notes
 
 This project uses SQLite for simplicity and stores generated QR codes in `static/qr/`.
-After a link is created you can customise its QR code from a pull-down menu next to the entry on your dashboard. Options include colours, module size, border width, pattern style, error correction level and an optional central logo.
+The creation form now only asks for the long URL so the interface stays clutter‑free. After a link is created you can customise its QR code from a pull‑down menu next to the entry on your dashboard. Options include colours, module size, border width, pattern style, error correction level and an optional central logo.
 
 The *rounded* pattern now uses a radius ratio of `1` so every module is drawn as
 a circle, providing a clear visual distinction from the default square style.

--- a/app.py
+++ b/app.py
@@ -376,7 +376,9 @@ def create_link():
     slug = generate_words()
     short_code = generate_short_code()
 
-    # Customisation options supplied by the user or using defaults
+    # Customisation options supplied by the user or using defaults.
+    # When the simplified creation form omits these fields the defaults are
+    # applied so a valid QR code is still generated.
     fill_color = request.form.get("fill_color", "#000000")
     back_color = request.form.get("back_color", "#FFFFFF")
     box_size = int(request.form.get("box_size", 10))

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Create new link</h2>
-<form method="post" action="{{ url_for('create_link') }}" enctype="multipart/form-data">
+<form method="post" action="{{ url_for('create_link') }}">
   <div class="mb-3">
     <label for="original_url" class="form-label">Long URL</label>
     <!--
@@ -12,45 +12,11 @@
     -->
     <input type="text" class="form-control" id="original_url" name="original_url" required>
   </div>
-  <div class="mb-3">
-    <label for="fill_color" class="form-label">Foreground Color</label>
-    <input type="color" class="form-control form-control-color" id="fill_color" name="fill_color" value="#000000">
-  </div>
-  <div class="mb-3">
-    <label for="back_color" class="form-label">Background Color</label>
-    <input type="color" class="form-control form-control-color" id="back_color" name="back_color" value="#ffffff">
-  </div>
-  <div class="row">
-    <div class="col-md-3 mb-3">
-      <label for="box_size" class="form-label">Box Size</label>
-      <input type="number" class="form-control" id="box_size" name="box_size" value="10" min="1" max="20">
-    </div>
-    <div class="col-md-3 mb-3">
-      <label for="border" class="form-label">Border</label>
-      <input type="number" class="form-control" id="border" name="border" value="4" min="0" max="10">
-    </div>
-    <div class="col-md-3 mb-3">
-      <label for="pattern" class="form-label">Pattern</label>
-      <select id="pattern" name="pattern" class="form-select">
-        <option value="square" selected>Square</option>
-        <option value="rounded">Rounded</option>
-        <option value="circle">Circle</option>
-      </select>
-    </div>
-    <div class="col-md-3 mb-3">
-      <label for="error_correction" class="form-label">Redundancy</label>
-      <select id="error_correction" name="error_correction" class="form-select">
-        <option value="L">L</option>
-        <option value="M" selected>M</option>
-        <option value="Q">Q</option>
-        <option value="H">H</option>
-      </select>
-    </div>
-  </div>
-  <div class="mb-3">
-    <label for="logo" class="form-label">Central Logo (optional)</label>
-    <input type="file" class="form-control" id="logo" name="logo" accept="image/*">
-  </div>
+  {#
+    The QR code customisation options previously available here have been
+    removed to keep the form simple. After the link is created, these settings
+    can be adjusted from the "Customize" pull-down next to each entry.
+  #}
   <button type="submit" class="btn btn-primary">Shorten</button>
 </form>
 


### PR DESCRIPTION
## Summary
- remove QR customisation options from dashboard link creation
- document new behaviour in README
- clarify default use of customisation in app code

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688522f4458883289883d731e3e6f69f