### PR TITLE
Add configurable paywall system

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
 - Dashboard listing a user's links and visit counts
 - Basic visit tracking (IP address and referrer)
 - Admin dashboard with site statistics and settings
+- Subscription paywall for advanced QR code features
 
 ## Setup
 
@@ -58,6 +59,10 @@ An administrator account is created automatically with the following credentials
 * **Password:** `Admin12345`
 
 Log in at `http://localhost:5000/admin/login` to view site statistics and manage settings such as the base URL used for generated links.
+
+### Monetisation
+
+Advanced features such as custom colours, advanced styling, logo embedding and analytics views are limited for free users. The monthly quotas for each feature can be configured from the admin settings page. Users marked as premium are not restricted by these limits.
 
 ## Notes
 

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -11,6 +11,23 @@
     -->
     <input type="text" class="form-control" id="base_url" name="base_url" value="{{ settings.base_url }}" required>
   </div>
+  <h3 class="mt-4">Free Monthly Usage Limits</h3>
+  <div class="mb-3">
+    <label for="custom_colors_limit" class="form-label">Custom Colours</label>
+    <input type="number" class="form-control" id="custom_colors_limit" name="custom_colors_limit" value="{{ settings.custom_colors_limit }}" min="0">
+  </div>
+  <div class="mb-3">
+    <label for="advanced_styles_limit" class="form-label">Advanced Styles</label>
+    <input type="number" class="form-control" id="advanced_styles_limit" name="advanced_styles_limit" value="{{ settings.advanced_styles_limit }}" min="0">
+  </div>
+  <div class="mb-3">
+    <label for="logo_embedding_limit" class="form-label">Logo Embedding</label>
+    <input type="number" class="form-control" id="logo_embedding_limit" name="logo_embedding_limit" value="{{ settings.logo_embedding_limit }}" min="0">
+  </div>
+  <div class="mb-3">
+    <label for="analytics_limit" class="form-label">Analytics Views</label>
+    <input type="number" class="form-control" id="analytics_limit" name="analytics_limit" value="{{ settings.analytics_limit }}" min="0">
+  </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add subscription counters and quotas
- let admins set free monthly limits
- enforce quotas when creating links and viewing analytics
- document paywall system

## Testing
- `python -m py_compile app.py run_rpi.py run_windows.py`

------
https://chatgpt.com/codex/tasks/task_e_6885282b64688328949c79c9639d2d05