### PR TITLE
Add page thumbnail previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
 - QR codes can be customised after creation from the dashboard
 - URLs missing a scheme are automatically prefixed with `https://`
 - Dashboard listing a user's links and visit counts
+- Thumbnail preview of each destination page using the thum.io service
 - Basic visit tracking (IP address and referrer)
 - Admin dashboard with site statistics and settings
 - Subscription paywall for advanced QR code features

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import random
 from datetime import datetime
 
 from flask import Flask, render_template, redirect, url_for, request, flash, send_from_directory, abort
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote_plus
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager, login_user, login_required, logout_user, current_user, UserMixin
 from sqlalchemy import func, text  # text() allows execution of raw SQL strings
@@ -92,6 +92,15 @@ class Link(db.Model):
         """Return the short URL using the base62 code."""
         base_url = get_settings().base_url.rstrip('/')
         return f"{base_url}/{self.short_code}"
+
+    @property
+    def thumbnail_url(self) -> str:
+        """Return a screenshot URL for the destination page."""
+        # Use the thum.io service which generates thumbnails from a URL.
+        # quote_plus ensures characters like '/' and ':' are encoded so
+        # the resulting URL is valid.
+        encoded = quote_plus(self.original_url)
+        return f"https://image.thum.io/get/width/300/{encoded}"
 
 
 class Visit(db.Model):

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -38,6 +38,8 @@
       </div>
       <div class="text-center mb-2">
         <img src="{{ url_for('serve_qr', filename=link.qr_filename) }}" width="100" class="mb-1">
+        <!-- Show a small screenshot of the original page -->
+        <img src="{{ link.thumbnail_url }}" width="100" class="mb-1" alt="Preview">
         <div>{{ link.visit_count }} visits</div>
         <div class="link-actions mt-1">
           <a href="{{ url_for('download_qr', filename=link.qr_filename) }}" class="btn btn-sm btn-secondary mb-1">


### PR DESCRIPTION
## Summary
- show a thumbnail preview in the dashboard for each link using thum.io
- expose `thumbnail_url` helper on Link
- document thumbnail preview feature in README

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68853244dcb083289cc3bdcfbf470c89