### PR TITLE
Add admin sidebar and user table

### DIFF
--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -19,16 +19,27 @@
     </div>
   </div>
 </nav>
-<div class="container">
-  {% with messages = get_flashed_messages() %}
-    {% if messages %}
-      <div class="alert alert-info">
-        {{ messages[0] }}
-      </div>
-    {% endif %}
-  {% endwith %}
+<div class="container-fluid">
+  <div class="row">
+    <nav class="col-md-2 col-lg-2 bg-light sidebar py-3">
+      <ul class="nav flex-column">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_dashboard') }}">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_users') }}">Users</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_settings') }}">Settings</a></li>
+      </ul>
+    </nav>
+    <main class="col-md-10 ms-sm-auto col-lg-10 px-md-4">
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <div class="alert alert-info">
+            {{ messages[0] }}
+          </div>
+        {% endif %}
+      {% endwith %}
 
-  {% block content %}{% endblock %}
+      {% block content %}{% endblock %}
+    </main>
+  </div>
 </div>
 </body>
 </html>

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,0 +1,34 @@
+{% extends 'admin_base.html' %}
+{% block content %}
+<h2>User Accounts</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Username</th>
+      <th>Premium</th>
+      <th>Links</th>
+      <th>Total Clicks</th>
+      <th>Payments</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in users %}
+    <tr>
+      <td>{{ row.user.username }}</td>
+      <td>{{ 'Yes' if row.user.is_premium else 'No' }}</td>
+      <td>{{ row.link_count }}</td>
+      <td>{{ row.total_clicks }}</td>
+      <td>
+        <ul class="list-unstyled mb-0">
+          {% for p in row.payments %}
+          <li>{{ p.timestamp.strftime('%Y-%m-%d') }} - ${{ '%.2f'|format(p.amount) }}</li>
+          {% else %}
+          <li>No payments</li>
+          {% endfor %}
+        </ul>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create Payment model and admin users route
- add sidebar navigation in admin layout
- show user management table with subscription and payment details

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_688533e0e1508328a0754b0bfe69fdc6