### PR TITLE
Add user freebies and basic subscription flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ Log in at `http://localhost:5000/admin/login` to view site statistics and manage
 
 Advanced features such as custom colours, advanced styling, logo embedding and analytics views are limited for free users. The monthly quotas for each feature can be configured from the admin settings page. Users marked as premium are not restricted by these limits.
 
+Each account also receives a small number of "freebies" every month which allow
+going over the free quotas. The remaining count and renewal date are displayed
+on the dashboard so users know when their allowance refreshes. Upgrading to the
+Pro plan removes all restrictions.
+
+Visit the new `/pricing` page for plan details and a simple upgrade form. The
+current early access program grants the Pro subscription for free but records
+the opt-in so payment processing can be integrated later.
+
 ## Notes
 
 This project uses SQLite for simplicity and stores generated QR codes in `static/qr/`.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import os
 import random
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import (
     Flask,
@@ -43,6 +43,9 @@ db = SQLAlchemy(app)
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
 
+# Number of extra premium actions granted to new/free accounts each month
+FREEBIES_PER_MONTH = 3
+
 # ----------------------------
 # Database Models
 # ----------------------------
@@ -61,6 +64,13 @@ class User(UserMixin, db.Model):
     advanced_styles_used = db.Column(db.Integer, default=0)
     logo_embedding_used = db.Column(db.Integer, default=0)
     analytics_used = db.Column(db.Integer, default=0)
+    # Track how many extra premium actions a free user may perform
+    freebies_remaining = db.Column(db.Integer, default=FREEBIES_PER_MONTH)
+    # Date when the freebies counter resets for the next period
+    freebies_reset = db.Column(
+        db.DateTime,
+        default=lambda: (datetime.utcnow().replace(day=1) + timedelta(days=32)).replace(day=1),
+    )
 
     def set_password(self, password: str) -> None:
         """Hash and store the user's password."""
@@ -360,6 +370,15 @@ def reset_usage_if_needed(user: User) -> None:
         user.analytics_used = 0
         db.session.commit()
 
+    # Freebies reset independently of the monthly counters. When the stored
+    # reset date is reached or passed, refresh the freebies allotment and set
+    # the next renewal for the first of the following month.
+    if user.freebies_reset and datetime.utcnow() >= user.freebies_reset:
+        user.freebies_remaining = FREEBIES_PER_MONTH
+        next_reset = user.freebies_reset.replace(day=1) + timedelta(days=32)
+        user.freebies_reset = next_reset.replace(day=1)
+        db.session.commit()
+
 
 def check_feature_usage(user: User, feature: str) -> bool:
     """Return True if the user may use the feature, recording usage."""
@@ -371,6 +390,13 @@ def check_feature_usage(user: User, feature: str) -> bool:
     limit = getattr(settings, limit_field)
     used = getattr(user, used_field)
     if used >= limit:
+        # Allow usage if the user still has freebies available. Each action
+        # consumes one freebie so users can sample premium features before
+        # subscribing.
+        if user.freebies_remaining > 0:
+            user.freebies_remaining -= 1
+            db.session.commit()
+            return True
         return False
     setattr(user, used_field, used + 1)
     db.session.commit()
@@ -437,6 +463,26 @@ def logout():
     """Log the current user out."""
     logout_user()
     return redirect(url_for('login'))
+
+
+@app.route('/pricing')
+def pricing():
+    """Display subscription options."""
+    return render_template('pricing.html')
+
+
+@app.route('/subscribe', methods=['GET', 'POST'])
+@login_required
+def subscribe():
+    """Upgrade the current user to a premium subscription."""
+    if request.method == 'POST':
+        current_user.is_premium = True
+        payment = Payment(user=current_user, amount=0.0)
+        db.session.add(payment)
+        db.session.commit()
+        flash('Subscription activated!')
+        return redirect(url_for('index'))
+    return render_template('subscribe.html')
 
 
 # ----------------------------
@@ -796,6 +842,8 @@ def initialize_database() -> None:
             'advanced_styles_used': 'INTEGER DEFAULT 0',
             'logo_embedding_used': 'INTEGER DEFAULT 0',
             'analytics_used': 'INTEGER DEFAULT 0',
+            'freebies_remaining': f'INTEGER DEFAULT {FREEBIES_PER_MONTH}',
+            'freebies_reset': 'DATETIME',
         }
         added_user_cols = False
         for column, ddl in user_map.items():
@@ -804,6 +852,14 @@ def initialize_database() -> None:
                 added_user_cols = True
 
         if added_user_cols:
+            db.session.commit()
+            # Initialise freebies for existing users so everyone starts
+            # with a full allocation once the new columns are added.
+            next_reset = (datetime.utcnow().replace(day=1) + timedelta(days=32)).replace(day=1)
+            User.query.update({
+                User.freebies_remaining: FREEBIES_PER_MONTH,
+                User.freebies_reset: next_reset,
+            })
             db.session.commit()
 
         # Retrieve column information for the link table so we can determine

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,13 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('index') }}">QRickLinks</a>
+    <div class="navbar-nav me-auto">
+      {% if current_user.is_authenticated and current_user.is_premium %}
+      <span class="nav-link disabled text-warning">Pro</span>
+      {% else %}
+      <a class="nav-link text-white" href="{{ url_for('pricing') }}">Pricing</a>
+      {% endif %}
+    </div>
     <div class="d-flex">
       {% if current_user.is_authenticated %}
       <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
+<div class="alert alert-secondary">
+  Freebies remaining: {{ current_user.freebies_remaining }}
+  (renews {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})
+</div>
 <h2>Create new link</h2>
 <form method="post" action="{{ url_for('create_link') }}">
   <div class="mb-3">

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Pricing</h2>
+<p>The Pro plan unlocks unlimited customisation and analytics. During early access the subscription is free.</p>
+{% if current_user.is_authenticated and not current_user.is_premium %}
+<a class="btn btn-primary" href="{{ url_for('subscribe') }}">Subscribe for Free</a>
+{% endif %}
+{% endblock %}

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Confirm Subscription</h2>
+<p>Click confirm to upgrade your account to Pro. No payment is required at this time.</p>
+<form method="post">
+  <button type="submit" class="btn btn-success">Confirm Upgrade</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- track monthly freebies and renewal date for each user
- show remaining freebies on dashboard
- add pricing page and subscription confirmation flow
- display `Pricing` link or `Pro` badge in the navbar
- document new monetisation features in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python app.py` *(started development server)*

------
https://chatgpt.com/codex/tasks/task_e_6885372c0fbc8328a99ce37045b211c9