### PR TITLE
Fix freebies display and restrict analytics

### DIFF
--- a/templates/link_details.html
+++ b/templates/link_details.html
@@ -1,6 +1,13 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Details for {{ link.slug }}</h2>
+{% if not premium %}
+<div class="text-center">
+  <span class="display-1">&#128274;</span>
+  <p class="mt-3">Analytics are a <strong>Pro</strong> feature.</p>
+  <a href="{{ url_for('pricing') }}" class="btn btn-primary">Upgrade</a>
+</div>
+{% else %}
 <p>Total Clicks: {{ total_clicks }}</p>
 <p>
   Unique Clicks: {{ unique_count }}
@@ -44,4 +51,5 @@
       });
   });
 </script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- refresh monthly usage counters when dashboard loads
- block analytics page for free users with an upgrade prompt

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68855136a1ac8328afa8c28acc74bdc2