### PR TITLE
Add pricing tiers configurator

### DIFF
--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -26,6 +26,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_dashboard') }}">Dashboard</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_users') }}">Users</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_settings') }}">Settings</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_tiers') }}">Pricing Tiers</a></li>
       </ul>
     </nav>
     <main class="col-md-10 ms-sm-auto col-lg-10 px-md-4">

--- a/templates/admin_tiers.html
+++ b/templates/admin_tiers.html
@@ -1,0 +1,72 @@
+{% extends 'admin_base.html' %}
+{% block content %}
+<h2>Pricing Tiers</h2>
+<form method="post">
+  <table class="table table-bordered text-center align-middle">
+    <thead>
+      <tr>
+        <th>Feature</th>
+        {% for tier in tiers %}
+        <th>
+          <input type="text" class="form-control mb-2" name="{{ tier.id }}_name" value="{{ tier.name }}">
+        </th>
+        {% endfor %}
+        <th>
+          <input type="text" class="form-control" name="new_tier_name" placeholder="New tier">
+          <button class="btn btn-primary btn-sm mt-2" type="submit">Add</button>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>Regular Price</th>
+        {% for tier in tiers %}
+        <td><input type="number" step="0.01" class="form-control" name="{{ tier.id }}_regular_price" value="{{ tier.regular_price }}"></td>
+        {% endfor %}
+        <td></td>
+      </tr>
+      <tr>
+        <th>Discounted Price</th>
+        {% for tier in tiers %}
+        <td><input type="number" step="0.01" class="form-control" name="{{ tier.id }}_discounted_price" value="{{ tier.discounted_price }}"></td>
+        {% endfor %}
+        <td></td>
+      </tr>
+      <tr>
+        <th>Highlight</th>
+        {% for tier in tiers %}
+        <td><input type="text" class="form-control" name="{{ tier.id }}_highlight_text" value="{{ tier.highlight_text }}"></td>
+        {% endfor %}
+        <td></td>
+      </tr>
+      {% for feat in features %}
+      <tr>
+        <th>{{ feat.replace('_',' ').title() }}</th>
+        {% for tier in tiers %}
+        <td>
+          <div class="input-group">
+            <input type="number" class="form-control" name="{{ tier.id }}_{{ feat }}_limit" value="{{ getattr(tier, feat + '_limit') }}">
+            <div class="input-group-text">
+              <input type="checkbox" class="form-check-input mt-0" name="{{ tier.id }}_{{ feat }}_unlimited" {% if getattr(tier, feat + '_unlimited') %}checked{% endif %}>
+            </div>
+          </div>
+        </td>
+        {% endfor %}
+        <td></td>
+      </tr>
+      {% endfor %}
+      <tr>
+        <th>Actions</th>
+        {% for tier in tiers %}
+        <td>
+          <a href="{{ url_for('delete_tier', tier_id=tier.id) }}" class="btn btn-danger btn-sm">Delete</a>
+          <a href="{{ url_for('archive_tier', tier_id=tier.id) }}" class="btn btn-secondary btn-sm">{{ 'Unarchive' if tier.archived else 'Archive' }}</a>
+        </td>
+        {% endfor %}
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <button type="submit" class="btn btn-primary">Save Changes</button>
+</form>
+{% endblock %}

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -1,8 +1,44 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Pricing</h2>
-<p>The Pro plan unlocks unlimited customisation and analytics. During early access the subscription is free.</p>
+<table class="table table-bordered text-center">
+  <thead>
+    <tr>
+      <th>Plan</th>
+      {% for tier in tiers %}
+      <th>
+        {{ tier.name }}
+        {% if tier.highlight_text %}<div class="text-muted">{{ tier.highlight_text }}</div>{% endif %}
+      </th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Regular Price</th>
+      {% for tier in tiers %}
+      <td>${{ '%.2f'|format(tier.regular_price) }}</td>
+      {% endfor %}
+    </tr>
+    <tr>
+      <th>Discounted Price</th>
+      {% for tier in tiers %}
+      <td>${{ '%.2f'|format(tier.discounted_price) }}</td>
+      {% endfor %}
+    </tr>
+    {% for feat in features %}
+    <tr>
+      <th>{{ feat.replace('_',' ').title() }}</th>
+      {% for tier in tiers %}
+      <td>
+        {% if getattr(tier, feat + '_unlimited') %}Unlimited{% else %}{{ getattr(tier, feat + '_limit') }}{% endif %}
+      </td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% if current_user.is_authenticated and not current_user.is_premium %}
-<a class="btn btn-primary" href="{{ url_for('subscribe') }}">Subscribe for Free</a>
+<a class="btn btn-primary" href="{{ url_for('subscribe') }}">Subscribe</a>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- create `SubscriptionTier` model for storing pricing tiers
- add admin interface at `/admin/tiers` for managing plans and limits
- display pricing tiers on the public pricing page
- link pricing tiers page from admin sidebar

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688554f0a95c8328a99cbba5aaee785f