### PR TITLE
Fix templates missing getattr

### DIFF
--- a/app.py
+++ b/app.py
@@ -495,7 +495,11 @@ def pricing():
         .all()
     )
     features = ['custom_colors', 'advanced_styles', 'logo_embedding', 'analytics']
-    return render_template('pricing.html', tiers=tiers, features=features)
+    # Pass the built-in ``getattr`` so Jinja can dynamically access
+    # tier limits/unlimited flags in the template.  Without this the
+    # templates raise an UndefinedError for ``getattr``.
+    return render_template('pricing.html', tiers=tiers, features=features,
+                           getattr=getattr)
 
 
 @app.route('/subscribe', methods=['GET', 'POST'])
@@ -622,7 +626,10 @@ def admin_tiers():
         db.session.commit()
         flash('Tiers updated')
         return redirect(url_for('admin_tiers'))
-    return render_template('admin_tiers.html', tiers=tiers, features=features)
+    # Provide ``getattr`` to the template so feature limits can be
+    # resolved dynamically for each tier column.
+    return render_template('admin_tiers.html', tiers=tiers,
+                           features=features, getattr=getattr)
 
 
 @app.route('/admin/tiers/delete/<int:tier_id>')


### PR DESCRIPTION
## Summary
- pass Python `getattr` function to templates
- update admin tiers view with documentation

## Testing
- `python -m py_compile app.py`
- `curl -s http://127.0.0.1:8000/pricing | head`
- `curl -b cookies.txt -s http://127.0.0.1:8000/admin/tiers | head`

------
https://chatgpt.com/codex/tasks/task_e_688558f98f9c8328bb44d5e0b32b9c34