### PR TITLE
Add user settings page

### DIFF
--- a/app.py
+++ b/app.py
@@ -518,6 +518,14 @@ def subscribe():
     return render_template('subscribe.html')
 
 
+@app.route('/settings')
+@login_required
+def user_settings():
+    """Display the user's subscription info and freebie balance."""
+    reset_usage_if_needed(current_user)
+    return render_template('user_settings.html')
+
+
 # ----------------------------
 # Admin Routes
 # ----------------------------

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,9 @@
       {% else %}
       <a class="nav-link text-white" href="{{ url_for('pricing') }}">Pricing</a>
       {% endif %}
+      {% if current_user.is_authenticated %}
+      <a class="nav-link text-white" href="{{ url_for('user_settings') }}">Settings</a>
+      {% endif %}
     </div>
     <div class="d-flex">
       {% if current_user.is_authenticated %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="alert alert-secondary">
   Freebies remaining: {{ current_user.freebies_remaining }}
-  (renews {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})
+  (resets {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})
 </div>
 <h2>Create new link</h2>
 <form method="post" action="{{ url_for('create_link') }}">

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Account Settings</h2>
+<div class="card mb-3">
+  <div class="card-body">
+    <p>Freebies remaining: {{ current_user.freebies_remaining }} (resets {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})</p>
+    {% if current_user.is_premium %}
+    <p>You have an active <strong>Pro</strong> subscription.</p>
+    {% else %}
+    <p>You are currently on the free plan.</p>
+    <a class="btn btn-primary" href="{{ url_for('pricing') }}">Upgrade</a>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- correct text about freebie renewal date
- add a new user settings page
- expose the settings page in the navigation

## Testing
- `python -m py_compile app.py rpi_qrlinks.py run_windows.py`

------
https://chatgpt.com/codex/tasks/task_e_6885d4a42ab08328bb22bcb177fc43ca