### PR TITLE
Add checkout placeholders

### DIFF
--- a/app.py
+++ b/app.py
@@ -514,6 +514,24 @@ def pricing():
                            getattr=getattr)
 
 
+@app.route('/checkout/<int:tier_id>', methods=['GET', 'POST'])
+@login_required
+def checkout(tier_id: int):
+    """Placeholder checkout page for purchasing a subscription tier."""
+    # Look up the selected tier or return 404 if it doesn't exist
+    tier = SubscriptionTier.query.get_or_404(tier_id)
+    if request.method == 'POST':
+        # Perform a fake transaction. The real payment logic will be added
+        # later using Stripe.
+        current_user.is_premium = True
+        payment = Payment(user=current_user, amount=tier.monthly_price)
+        db.session.add(payment)
+        db.session.commit()
+        flash(f'Subscribed to {tier.name}!')
+        return redirect(url_for('index'))
+    return render_template('checkout.html', tier=tier)
+
+
 @app.route('/subscribe', methods=['GET', 'POST'])
 @login_required
 def subscribe():

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Checkout: {{ tier.name }}</h2>
+{# Placeholder messaging until Stripe integration is implemented #}
+<p>This is a placeholder checkout page. Payment processing will be added soon.</p>
+<form method="post">
+  <button type="submit" class="btn btn-success">Complete Purchase</button>
+  <a href="{{ url_for('pricing') }}" class="btn btn-secondary ms-2">Cancel</a>
+</form>
+{% endblock %}

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -44,6 +44,14 @@
       <td class="total-cell" data-monthly="{{ tier.monthly_price }}" data-yearly="{{ tier.yearly_price }}"></td>
       {% endfor %}
     </tr>
+    <tr>
+      <th></th>
+      {% for tier in tiers %}
+      <td>
+        <a class="btn btn-success" href="{{ url_for('checkout', tier_id=tier.id) }}">Buy Now</a>
+      </td>
+      {% endfor %}
+    </tr>
   </tbody>
 </table>
 {% if current_user.is_authenticated and not current_user.is_premium %}


### PR DESCRIPTION
## Summary
- add a checkout route with placeholder logic until Stripe is integrated
- add Buy Now buttons in the pricing table
- include a simple checkout template

## Testing
- `python -m py_compile app.py rpi_qrlinks.py`

------
https://chatgpt.com/codex/tasks/task_e_6885dc3c7af48328ba463b42821c2d66