### PR TITLE
Add My Account page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
 - Basic visit tracking (IP address and referrer)
 - Admin dashboard with site statistics and settings
 - Subscription paywall for advanced QR code features
+- Personal "My Account" page to manage quotas, billing info and subscription
 
 ## Setup
 

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>My Account</h2>
+<div class="card mb-3">
+  <div class="card-body">
+    <h5 class="card-title">Subscription</h5>
+    {% if current_user.is_premium %}
+    <p class="card-text">You have an active <strong>Pro</strong> subscription.</p>
+    <p>Next renewal: {{ current_user.subscription_renewal.strftime('%Y-%m-%d') if current_user.subscription_renewal else 'N/A' }}</p>
+    <form method="post" action="{{ url_for('cancel_subscription') }}">
+      <button type="submit" class="btn btn-danger">Cancel Subscription</button>
+    </form>
+    {% else %}
+    <p class="card-text">You are currently on the free plan.</p>
+    <a class="btn btn-primary" href="{{ url_for('pricing') }}">Upgrade</a>
+    {% endif %}
+  </div>
+</div>
+<h3>Usage Quotas</h3>
+<table class="table table-bordered mb-4">
+  <thead><tr><th>Feature</th><th>Remaining</th></tr></thead>
+  <tbody>
+    {% for feat, remaining in quotas.items() %}
+    <tr><td>{{ feat.replace('_',' ').title() }}</td><td>{{ remaining }}</td></tr>
+    {% endfor %}
+    <tr><td>Freebies</td><td>{{ current_user.freebies_remaining }}</td></tr>
+  </tbody>
+</table>
+<h3>Billing Information</h3>
+<form method="post">
+  <div class="mb-3">
+    <label for="billing_name" class="form-label">Name on Card</label>
+    <input type="text" class="form-control" id="billing_name" name="billing_name" value="{{ current_user.billing_name or '' }}">
+  </div>
+  <div class="mb-3">
+    <label for="billing_card_last4" class="form-label">Card Last 4 Digits</label>
+    <input type="text" class="form-control" id="billing_card_last4" name="billing_card_last4" value="{{ current_user.billing_card_last4 or '' }}">
+  </div>
+  <div class="mb-3">
+    <label for="billing_expiry" class="form-label">Expiry (MM/YYYY)</label>
+    <input type="text" class="form-control" id="billing_expiry" name="billing_expiry" value="{{ current_user.billing_expiry or '' }}">
+  </div>
+  <button type="submit" class="btn btn-primary">Save Billing Info</button>
+</form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,7 @@
       <a class="nav-link text-white" href="{{ url_for('pricing') }}">Pricing</a>
       {% endif %}
       {% if current_user.is_authenticated %}
-      <a class="nav-link text-white" href="{{ url_for('user_settings') }}">Settings</a>
+      <a class="nav-link text-white" href="{{ url_for('account') }}">My Account</a>
       {% endif %}
     </div>
     <div class="d-flex">


### PR DESCRIPTION
## Summary
- extend `User` model with billing info fields
- add `/account` page for quotas and billing management
- allow subscription cancellation via `/cancel_subscription`
- link to new page from navigation
- document new My Account feature in README

## Testing
- `python -m py_compile app.py rpi_qrlinks.py run_windows.py`

------
https://chatgpt.com/codex/tasks/task_e_6885df1fb4a48328b8a99c3d62d093b3