### PR TITLE
Fix subscription tier logic

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -38,6 +38,12 @@ body {
   align-items: stretch;
 }
 
+/* Disabled action buttons should appear inactive and ignore clicks */
+.btn.disabled {
+  pointer-events: none;
+  opacity: 0.65;
+}
+
 
 /* Highlight long URL input with a complementary colour */
 #original_url {

--- a/templates/account.html
+++ b/templates/account.html
@@ -4,14 +4,14 @@
 <div class="card mb-3">
   <div class="card-body">
     <h5 class="card-title">Subscription</h5>
-    {% if current_user.is_premium %}
-    <p class="card-text">You have an active <strong>Pro</strong> subscription.</p>
+    {% if current_user.tier and current_user.tier.name != 'Free' %}
+    <p class="card-text">You have an active <strong>{{ current_user.tier.name }}</strong> subscription.</p>
     <p>Next renewal: {{ current_user.subscription_renewal.strftime('%Y-%m-%d') if current_user.subscription_renewal else 'N/A' }}</p>
     <form method="post" action="{{ url_for('cancel_subscription') }}">
       <button type="submit" class="btn btn-danger">Cancel Subscription</button>
     </form>
     {% else %}
-    <p class="card-text">You are currently on the free plan.</p>
+    <p class="card-text">You are currently on the Free plan.</p>
     <a class="btn btn-primary" href="{{ url_for('pricing') }}">Upgrade</a>
     {% endif %}
   </div>

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -5,7 +5,7 @@
   <thead>
     <tr>
       <th>Username</th>
-      <th>Premium</th>
+      <th>Tier</th>
       <th>Links</th>
       <th>Total Clicks</th>
       <th>Payments</th>
@@ -15,7 +15,7 @@
     {% for row in users %}
     <tr>
       <td>{{ row.user.username }}</td>
-      <td>{{ 'Yes' if row.user.is_premium else 'No' }}</td>
+      <td>{{ row.user.tier.name if row.user.tier else 'Free' }}</td>
       <td>{{ row.link_count }}</td>
       <td>{{ row.total_clicks }}</td>
       <td>

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,8 +19,8 @@
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('index') }}">QRickLinks</a>
     <div class="navbar-nav me-auto">
-      {% if current_user.is_authenticated and current_user.is_premium %}
-      <span class="nav-link disabled text-warning">Pro</span>
+      {% if current_user.is_authenticated and current_user.tier and current_user.tier.name != 'Free' %}
+      <span class="nav-link disabled text-warning">{{ current_user.tier.name }}</span>
       {% else %}
       <a class="nav-link text-white" href="{{ url_for('pricing') }}">Pricing</a>
       {% endif %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -25,7 +25,11 @@
     removed to keep the form simple. After the link is created, these settings
     can be adjusted from the "Customize" pull-down next to each entry.
   #}
+  {% if can_create %}
   <button type="submit" class="btn btn-primary">Shorten</button>
+  {% else %}
+  <a class="btn btn-primary disabled" href="{{ url_for('pricing') }}">Shorten</a>
+  {% endif %}
 </form>
 
 <hr>

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -54,7 +54,7 @@
     </tr>
   </tbody>
 </table>
-{% if current_user.is_authenticated and not current_user.is_premium %}
+{% if current_user.is_authenticated and (not current_user.tier or current_user.tier.name == 'Free') %}
 <a class="btn btn-primary" href="{{ url_for('subscribe') }}">Subscribe</a>
 {% endif %}
 <script>

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -4,8 +4,8 @@
 <div class="card mb-3">
   <div class="card-body">
     <p>Freebies remaining: {{ current_user.freebies_remaining }} (resets {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})</p>
-    {% if current_user.is_premium %}
-    <p>You have an active <strong>Pro</strong> subscription.</p>
+    {% if current_user.tier and current_user.tier.name != 'Free' %}
+    <p>You have an active <strong>{{ current_user.tier.name }}</strong> subscription.</p>
     {% else %}
     <p>You are currently on the free plan.</p>
     <a class="btn btn-primary" href="{{ url_for('pricing') }}">Upgrade</a>


### PR DESCRIPTION
## Summary
- track each user's active subscription tier
- check quotas against tier settings
- show remaining quota in account page
- disable link creation when out of quota
- update templates to show tier names instead of Pro flag
- add CSS for disabled buttons

## Testing
- `python -m py_compile app.py`
- `flake8 app.py` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_6885e3f1f71c8328b9359a1afc296cd1