### PR TITLE
Remove freebies banner

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,9 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="alert alert-secondary">
-  Freebies remaining: {{ current_user.freebies_remaining }}
-  (resets {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})
-</div>
+{#
+  Removed the freebies reminder from the top of the dashboard. The
+  user request was to hide the "Freebies remaining" banner. Existing
+  template logic remains unchanged except for the omission of this
+  notice.
+#}
 <h2>Create new link</h2>
 <form method="post" action="{{ url_for('create_link') }}">
   <div class="mb-3">


### PR DESCRIPTION
## Summary
- remove the freebies reminder section from the dashboard

## Testing
- `python -m py_compile app.py rpi_qrlinks.py run_windows.py`

------
https://chatgpt.com/codex/tasks/task_e_6885e8bf80508328a833c6b822e309b5