### PR TITLE
Make secret key configurable via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the application:
+2. Optionally set a custom `SECRET_KEY` used to sign session cookies:
+   ```bash
+   export SECRET_KEY="your-secret-string"
+   ```
+3. Run the application:
    ```bash
    python app.py
    ```
-3. Visit `http://localhost:5000` in your browser.
+4. Visit `http://localhost:5000` in your browser.
 
 ### Raspberry Pi Hosting
 

--- a/app.py
+++ b/app.py
@@ -35,7 +35,9 @@ from PIL import ImageColor
 
 # Initialize Flask app and database
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'change-this-secret-key'
+# Use a secret key from the environment if available so deployments can set
+# their own value. A hard-coded default keeps development setups simple.
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'change-this-secret-key')
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///qricklinks.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 


### PR DESCRIPTION
## Summary
- allow SECRET_KEY to be read from `os.environ`
- update setup instructions about SECRET_KEY

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install Flask Flask-Login Flask-SQLAlchemy qrcode Pillow waitress`
- `python app.py & sleep 3; pkill -f app.py`


------
https://chatgpt.com/codex/tasks/task_e_6886027ff68c83288000e04ab8999e65