### PR TITLE
Add custom slug option

### DIFF
--- a/app.py
+++ b/app.py
@@ -783,7 +783,11 @@ def create_link():
     if not check_feature_usage(current_user, 'links'):
         flash('Link creation quota exceeded')
         return redirect(url_for('index'))
-    slug = generate_words()
+    # Use the submitted slug when provided. Falling back to a randomly
+    # generated "adjective.adjective.noun" slug keeps behaviour unchanged
+    # for users who leave the slug field blank.
+    submitted_slug = request.form.get("slug", "").strip()
+    slug = submitted_slug or generate_words()
     short_code = generate_short_code()
 
     # Customisation options supplied by the user or using defaults.
@@ -818,7 +822,8 @@ def create_link():
         flash('Logo embedding quota exceeded')
         return redirect(url_for('index'))
 
-    # Ensure slugs and codes are unique; regenerate if a collision occurs
+    # Ensure slugs and codes are unique. If the requested slug already exists
+    # a new random slug is generated so link creation always succeeds.
     while Link.query.filter_by(slug=slug).first() is not None:
         slug = generate_words()
     while Link.query.filter_by(short_code=short_code).first() is not None:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -22,6 +22,14 @@
       colour so the entry box stands out against the surrounding form.
     -->
   </div>
+  <div class="mb-3">
+    <label for="slug" class="form-label">Slug</label>
+    <!--
+      Allow the user to specify a custom slug for their short URL. If left
+      blank the server will generate a random slug instead.
+    -->
+    <input type="text" class="form-control" id="slug" name="slug" placeholder="optional">
+  </div>
   {#
     The QR code customisation options previously available here have been
     removed to keep the form simple. After the link is created, these settings


### PR DESCRIPTION
## Summary
- allow optional slug field in dashboard link creation form
- use the submitted slug in `create_link` if provided, falling back to random slug
- ensure slug uniqueness by regenerating when duplicates are found

## Testing
- `python -m py_compile app.py rpi_qrlinks.py`

------
https://chatgpt.com/codex/tasks/task_e_688602e5100083288f9e574e1d576304