### PR TITLE
Implement colour palette tiers and themes

### DIFF
--- a/templates/admin_tiers.html
+++ b/templates/admin_tiers.html
@@ -39,6 +39,22 @@
         {% endfor %}
         <td></td>
       </tr>
+      <tr>
+        <th>Colour Palette</th>
+        {% for tier in tiers %}
+        <td>
+          <div class="form-check">
+            <input class="form-check-input" type="radio" name="{{ tier.id }}_palette" value="limited" {% if not tier.full_palette %}checked{% endif %}>
+            <label class="form-check-label">16 colours</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="radio" name="{{ tier.id }}_palette" value="full" {% if tier.full_palette %}checked{% endif %}>
+            <label class="form-check-label">Full colour</label>
+          </div>
+        </td>
+        {% endfor %}
+        <td></td>
+      </tr>
       {% for feat in features %}
       <tr>
         <th>{{ feat.replace('_',' ').title() }}</th>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -91,25 +91,50 @@
     </div>
     <div class="collapse mt-2" id="c{{ link.id }}">
       <form method="post" action="{{ url_for('customize_link', link_id=link.id) }}" enctype="multipart/form-data" class="row g-2">
+          <div class="col-md-3">
+            <label class="form-label">Apply Theme</label>
+            <select name="theme_id" class="form-select" {% if not can_colors and not can_styles %}disabled{% endif %}>
+              <option value="">-- none --</option>
+              {% for t in themes %}
+              <option value="{{ t.id }}" {% if t.is_default %}selected{% endif %}>{{ t.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
           <div class="col-md-2">
             <label for="fill_color{{ link.id }}" class="form-label">Foreground</label>
-            <input type="color" class="form-control form-control-color" id="fill_color{{ link.id }}" name="fill_color" value="{{ link.fill_color }}">
+            {% if palette_full %}
+            <input type="color" class="form-control form-control-color" id="fill_color{{ link.id }}" name="fill_color" value="{{ link.fill_color }}" {% if not can_colors %}disabled{% endif %}>
+            {% else %}
+            <select id="fill_color{{ link.id }}" name="fill_color" class="form-select" {% if not can_colors %}disabled{% endif %}>
+              {% for col in limited_palette %}
+              <option value="{{ col }}" style="background-color: {{ col }};" {% if link.fill_color==col %}selected{% endif %}>{{ col }}</option>
+              {% endfor %}
+            </select>
+            {% endif %}
           </div>
           <div class="col-md-2">
             <label for="back_color{{ link.id }}" class="form-label">Background</label>
-            <input type="color" class="form-control form-control-color" id="back_color{{ link.id }}" name="back_color" value="{{ link.back_color }}">
+            {% if palette_full %}
+            <input type="color" class="form-control form-control-color" id="back_color{{ link.id }}" name="back_color" value="{{ link.back_color }}" {% if not can_colors %}disabled{% endif %}>
+            {% else %}
+            <select id="back_color{{ link.id }}" name="back_color" class="form-select" {% if not can_colors %}disabled{% endif %}>
+              {% for col in limited_palette %}
+              <option value="{{ col }}" style="background-color: {{ col }};" {% if link.back_color==col %}selected{% endif %}>{{ col }}</option>
+              {% endfor %}
+            </select>
+            {% endif %}
           </div>
           <div class="col-md-1">
             <label for="box_size{{ link.id }}" class="form-label">Box</label>
-            <input type="number" class="form-control" id="box_size{{ link.id }}" name="box_size" value="{{ link.box_size }}" min="1" max="20">
+            <input type="number" class="form-control" id="box_size{{ link.id }}" name="box_size" value="{{ link.box_size }}" min="1" max="20" {% if not can_styles %}disabled{% endif %}>
           </div>
           <div class="col-md-1">
             <label for="border{{ link.id }}" class="form-label">Border</label>
-            <input type="number" class="form-control" id="border{{ link.id }}" name="border" value="{{ link.border }}" min="0" max="10">
+            <input type="number" class="form-control" id="border{{ link.id }}" name="border" value="{{ link.border }}" min="0" max="10" {% if not can_styles %}disabled{% endif %}>
           </div>
           <div class="col-md-2">
             <label for="pattern{{ link.id }}" class="form-label">Pattern</label>
-            <select id="pattern{{ link.id }}" name="pattern" class="form-select">
+            <select id="pattern{{ link.id }}" name="pattern" class="form-select" {% if not can_styles %}disabled{% endif %}>
               <option value="square" {% if link.pattern == 'square' %}selected{% endif %}>Square</option>
               <option value="rounded" {% if link.pattern == 'rounded' %}selected{% endif %}>Rounded</option>
               <option value="circle" {% if link.pattern == 'circle' %}selected{% endif %}>Circle</option>
@@ -117,7 +142,7 @@
           </div>
           <div class="col-md-2">
             <label for="error_correction{{ link.id }}" class="form-label">Redundancy</label>
-            <select id="error_correction{{ link.id }}" name="error_correction" class="form-select">
+            <select id="error_correction{{ link.id }}" name="error_correction" class="form-select" {% if not can_styles %}disabled{% endif %}>
               <option value="L" {% if link.error_correction == 'L' %}selected{% endif %}>L</option>
               <option value="M" {% if link.error_correction == 'M' %}selected{% endif %}>M</option>
               <option value="Q" {% if link.error_correction == 'Q' %}selected{% endif %}>Q</option>

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -28,6 +28,12 @@
       <td class="price-cell" data-monthly="{{ tier.monthly_price }}" data-yearly="{{ tier.yearly_price }}"></td>
       {% endfor %}
     </tr>
+    <tr>
+      <th>Colour Palette</th>
+      {% for tier in tiers %}
+      <td>{{ 'Full colour' if tier.full_palette else '16 colours' }}</td>
+      {% endfor %}
+    </tr>
     {% for feat in features %}
     <tr>
       <th>{{ feat.replace('_',' ').title() }}</th>

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -1,15 +1,125 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Account Settings</h2>
-<div class="card mb-3">
-  <div class="card-body">
-    <p>Freebies remaining: {{ current_user.freebies_remaining }} (resets {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})</p>
-    {% if current_user.tier and current_user.tier.name != 'Free' %}
-    <p>You have an active <strong>{{ current_user.tier.name }}</strong> subscription.</p>
+<h2>Colour Themes</h2>
+<div class="mb-3">
+  <p>Freebies remaining: {{ current_user.freebies_remaining }} (resets {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})</p>
+</div>
+{% for t in themes %}
+<form method="post" class="row g-2 align-items-end mb-3">
+  <input type="hidden" name="theme_id" value="{{ t.id }}">
+  <div class="col-md-2">
+    <input type="text" class="form-control" name="name" value="{{ t.name }}" required>
+  </div>
+  <div class="col-md-2">
+    {% if palette_full %}
+    <input type="color" class="form-control form-control-color" name="fill_color" value="{{ t.fill_color }}">
     {% else %}
-    <p>You are currently on the free plan.</p>
-    <a class="btn btn-primary" href="{{ url_for('pricing') }}">Upgrade</a>
+    <select class="form-select" name="fill_color">
+      {% for col in limited_palette %}
+      <option value="{{ col }}" style="background-color: {{ col }};" {% if t.fill_color==col %}selected{% endif %}>{{ col }}</option>
+      {% endfor %}
+    </select>
     {% endif %}
   </div>
-</div>
+  <div class="col-md-2">
+    {% if palette_full %}
+    <input type="color" class="form-control form-control-color" name="back_color" value="{{ t.back_color }}">
+    {% else %}
+    <select class="form-select" name="back_color">
+      {% for col in limited_palette %}
+      <option value="{{ col }}" style="background-color: {{ col }};" {% if t.back_color==col %}selected{% endif %}>{{ col }}</option>
+      {% endfor %}
+    </select>
+    {% endif %}
+  </div>
+  <div class="col-md-1">
+    <input type="number" class="form-control" name="box_size" value="{{ t.box_size }}" min="1" max="20">
+  </div>
+  <div class="col-md-1">
+    <input type="number" class="form-control" name="border" value="{{ t.border }}" min="0" max="10">
+  </div>
+  <div class="col-md-2">
+    <select name="pattern" class="form-select">
+      <option value="square" {% if t.pattern=='square' %}selected{% endif %}>Square</option>
+      <option value="rounded" {% if t.pattern=='rounded' %}selected{% endif %}>Rounded</option>
+      <option value="circle" {% if t.pattern=='circle' %}selected{% endif %}>Circle</option>
+    </select>
+  </div>
+  <div class="col-md-1">
+    <select name="error_correction" class="form-select">
+      <option value="L" {% if t.error_correction=='L' %}selected{% endif %}>L</option>
+      <option value="M" {% if t.error_correction=='M' %}selected{% endif %}>M</option>
+      <option value="Q" {% if t.error_correction=='Q' %}selected{% endif %}>Q</option>
+      <option value="H" {% if t.error_correction=='H' %}selected{% endif %}>H</option>
+    </select>
+  </div>
+  <div class="col-md-1 text-center">
+    <input class="form-check-input" type="radio" name="is_default" value="on" {% if t.is_default %}checked{% endif %}>
+  </div>
+  <div class="col-md-1">
+    <button type="submit" name="update_theme" class="btn btn-sm btn-primary">Save</button>
+  </div>
+  <div class="col-md-1">
+    <button type="submit" name="delete_theme" value="{{ t.id }}" class="btn btn-sm btn-danger">Delete</button>
+  </div>
+</form>
+{% endfor %}
+{% if can_add %}
+<form method="post" class="row g-2 align-items-end">
+  <div class="col-md-2">
+    <input type="text" class="form-control" name="name" placeholder="Theme name" required>
+  </div>
+  <div class="col-md-2">
+    {% if palette_full %}
+    <input type="color" class="form-control form-control-color" name="fill_color" value="#000000">
+    {% else %}
+    <select class="form-select" name="fill_color">
+      {% for col in limited_palette %}
+      <option value="{{ col }}" style="background-color: {{ col }};">{{ col }}</option>
+      {% endfor %}
+    </select>
+    {% endif %}
+  </div>
+  <div class="col-md-2">
+    {% if palette_full %}
+    <input type="color" class="form-control form-control-color" name="back_color" value="#FFFFFF">
+    {% else %}
+    <select class="form-select" name="back_color">
+      {% for col in limited_palette %}
+      <option value="{{ col }}" style="background-color: {{ col }};">{{ col }}</option>
+      {% endfor %}
+    </select>
+    {% endif %}
+  </div>
+  <div class="col-md-1">
+    <input type="number" class="form-control" name="box_size" value="10" min="1" max="20">
+  </div>
+  <div class="col-md-1">
+    <input type="number" class="form-control" name="border" value="4" min="0" max="10">
+  </div>
+  <div class="col-md-2">
+    <select name="pattern" class="form-select">
+      <option value="square">Square</option>
+      <option value="rounded">Rounded</option>
+      <option value="circle">Circle</option>
+    </select>
+  </div>
+  <div class="col-md-1">
+    <select name="error_correction" class="form-select">
+      <option value="L">L</option>
+      <option value="M" selected>M</option>
+      <option value="Q">Q</option>
+      <option value="H">H</option>
+    </select>
+  </div>
+  <div class="col-md-1 text-center">
+    <input class="form-check-input" type="radio" name="is_default">
+  </div>
+  <div class="col-md-1">
+    <button type="submit" name="create_theme" class="btn btn-sm btn-success">Add</button>
+  </div>
+</form>
+{% else %}
+<p>You have reached your colour theme quota.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add subscription tier options for colour palette (16 colours vs full colour)
- introduce ColourTheme model with CRUD UI
- implement palette selection and theme limits in admin interface
- allow users to create/manage themes and apply them when customising links
- restrict colour selection inputs based on subscription tier

## Testing
- `python -m py_compile app.py`
- `find . -name "*.py" -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_688609f676f8832895d212208c9a101a