### PR TITLE
Enable CSRF protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ QRickLinks is a simple URL shortening service that generates short, memorable sl
    ```bash
    pip install -r requirements.txt
    ```
+   The project now depends on **Flask-WTF** to provide CSRF protection,
+   so ensure it is installed when setting up the environment.
 2. Optionally set a custom `SECRET_KEY` used to sign session cookies:
    ```bash
    export SECRET_KEY="your-secret-string"

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from flask import (
 from urllib.parse import urlparse, quote
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager, login_user, login_required, logout_user, current_user, UserMixin
+from flask_wtf import CSRFProtect
 from itsdangerous import URLSafeTimedSerializer
 from flask_dance.contrib.google import make_google_blueprint, google
 from sqlalchemy import func, text  # text() allows execution of raw SQL strings
@@ -44,6 +45,8 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///qricklinks.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db = SQLAlchemy(app)
+# Enable CSRF protection for all POST forms using Flask-WTF
+csrf = CSRFProtect(app)
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask
 Flask-Login
 Flask-SQLAlchemy
+Flask-WTF
 qrcode
 Pillow
 waitress

--- a/templates/account.html
+++ b/templates/account.html
@@ -8,6 +8,7 @@
     <p class="card-text">You have an active <strong>{{ current_user.tier.name }}</strong> subscription.</p>
     <p>Next renewal: {{ current_user.subscription_renewal.strftime('%Y-%m-%d') if current_user.subscription_renewal else 'N/A' }}</p>
     <form method="post" action="{{ url_for('cancel_subscription') }}">
+      {{ csrf_token() }}
       <button type="submit" class="btn btn-danger">Cancel Subscription</button>
     </form>
     {% else %}
@@ -28,6 +29,7 @@
 </table>
 <h3>Billing Information</h3>
 <form method="post">
+  {{ csrf_token() }}
   <div class="mb-3">
     <label for="billing_name" class="form-label">Name on Card</label>
     <input type="text" class="form-control" id="billing_name" name="billing_name" value="{{ current_user.billing_name or '' }}">

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Admin Login</h2>
 <form method="post">
+  {{ csrf_token() }}
   <div class="mb-3">
     <label for="username" class="form-label">Username</label>
     <input type="text" class="form-control" id="username" name="username" required>

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Global Settings</h2>
 <form method="post">
+  {{ csrf_token() }}
   <div class="mb-3">
     <label for="base_url" class="form-label">Base URL</label>
     <!--

--- a/templates/admin_tiers.html
+++ b/templates/admin_tiers.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Pricing Tiers</h2>
 <form method="post">
+  {{ csrf_token() }}
   <table class="table table-bordered text-center align-middle">
     <thead>
       <tr>

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -4,6 +4,7 @@
 {# Placeholder messaging until Stripe integration is implemented #}
 <p>This is a placeholder checkout page. Payment processing will be added soon.</p>
 <form method="post">
+  {{ csrf_token() }}
   <button type="submit" class="btn btn-success">Complete Purchase</button>
   <a href="{{ url_for('pricing') }}" class="btn btn-secondary ms-2">Cancel</a>
 </form>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -8,6 +8,7 @@
 #}
 <h2>Create new link</h2>
 <form method="post" action="{{ url_for('create_link') }}">
+  {{ csrf_token() }}
   <div class="mb-3">
     <label for="original_url" class="form-label">Long URL</label>
     <!--
@@ -82,6 +83,7 @@
             <span class="icon-sm">C</span><span class="text-label">Customize</span>
           </button>
           <form method="post" action="{{ url_for('delete_link', link_id=link.id) }}">
+            {{ csrf_token() }}
             <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this link and all visit records? This cannot be undone.');">
               <span class="icon-sm">X</span><span class="text-label">Delete</span>
             </button>
@@ -91,6 +93,7 @@
     </div>
     <div class="collapse mt-2" id="c{{ link.id }}">
       <form method="post" action="{{ url_for('customize_link', link_id=link.id) }}" enctype="multipart/form-data" class="row g-2">
+          {{ csrf_token() }}
           <div class="col-md-3">
             <label class="form-label">Apply Theme</label>
             <select name="theme_id" class="form-select" {% if not can_colors and not can_styles %}disabled{% endif %}>

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Forgot Password</h2>
 <form method="post">
+  {{ csrf_token() }}
   <div class="mb-3">
     <label for="email" class="form-label">Email</label>
     <input type="email" class="form-control" id="email" name="email" required>

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Login</h2>
 <form method="post">
+  {{ csrf_token() }}
   <div class="mb-3">
     <label for="email" class="form-label">Email</label>
     <input type="text" class="form-control" id="email" name="email" required>

--- a/templates/register.html
+++ b/templates/register.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Register</h2>
 <form method="post">
+  {{ csrf_token() }}
   <div class="mb-3">
     <label for="username" class="form-label">Username</label>
     <input type="text" class="form-control" id="username" name="username" required>

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Reset Password</h2>
 <form method="post">
+  {{ csrf_token() }}
   <div class="mb-3">
     <label for="password" class="form-label">New Password</label>
     <input type="password" class="form-control" id="password" name="password" required>

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -3,6 +3,7 @@
 <h2>Confirm Subscription</h2>
 <p>Click confirm to upgrade your account to Pro. No payment is required at this time.</p>
 <form method="post">
+  {{ csrf_token() }}
   <button type="submit" class="btn btn-success">Confirm Upgrade</button>
 </form>
 {% endblock %}

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -6,6 +6,7 @@
 </div>
 {% for t in themes %}
 <form method="post" class="row g-2 align-items-end mb-3">
+  {{ csrf_token() }}
   <input type="hidden" name="theme_id" value="{{ t.id }}">
   <div class="col-md-2">
     <input type="text" class="form-control" name="name" value="{{ t.name }}" required>
@@ -66,6 +67,7 @@
 {% endfor %}
 {% if can_add %}
 <form method="post" class="row g-2 align-items-end">
+  {{ csrf_token() }}
   <div class="col-md-2">
     <input type="text" class="form-control" name="name" placeholder="Theme name" required>
   </div>


### PR DESCRIPTION
## Summary
- add `Flask-WTF` to requirements
- initialize CSRF protection in `app.py`
- inject CSRF tokens into all forms
- mention the new dependency in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68860c9669a083288d38207351d77742