### PR TITLE
Fix visible CSRF tokens

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -8,7 +8,8 @@
     <p class="card-text">You have an active <strong>{{ current_user.tier.name }}</strong> subscription.</p>
     <p>Next renewal: {{ current_user.subscription_renewal.strftime('%Y-%m-%d') if current_user.subscription_renewal else 'N/A' }}</p>
     <form method="post" action="{{ url_for('cancel_subscription') }}">
-      {{ csrf_token() }}
+      <!-- CSRF field validates the cancellation request -->
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <button type="submit" class="btn btn-danger">Cancel Subscription</button>
     </form>
     {% else %}
@@ -29,7 +30,8 @@
 </table>
 <h3>Billing Information</h3>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- Protect the billing update form -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="billing_name" class="form-label">Name on Card</label>
     <input type="text" class="form-control" id="billing_name" name="billing_name" value="{{ current_user.billing_name or '' }}">

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -2,7 +2,8 @@
 {% block content %}
 <h2>Admin Login</h2>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- CSRF token prevents cross-site attacks -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="username" class="form-label">Username</label>
     <input type="text" class="form-control" id="username" name="username" required>

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -2,7 +2,8 @@
 {% block content %}
 <h2>Global Settings</h2>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- Hidden token protects admin settings form -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="base_url" class="form-label">Base URL</label>
     <!--

--- a/templates/admin_tiers.html
+++ b/templates/admin_tiers.html
@@ -2,7 +2,8 @@
 {% block content %}
 <h2>Pricing Tiers</h2>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- Admin tier changes require CSRF protection -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <table class="table table-bordered text-center align-middle">
     <thead>
       <tr>

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -4,7 +4,8 @@
 {# Placeholder messaging until Stripe integration is implemented #}
 <p>This is a placeholder checkout page. Payment processing will be added soon.</p>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- Include CSRF token on checkout form -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <button type="submit" class="btn btn-success">Complete Purchase</button>
   <a href="{{ url_for('pricing') }}" class="btn btn-secondary ms-2">Cancel</a>
 </form>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -8,7 +8,8 @@
 #}
 <h2>Create new link</h2>
 <form method="post" action="{{ url_for('create_link') }}">
-  {{ csrf_token() }}
+  <!-- Hidden CSRF field prevents form tampering -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="original_url" class="form-label">Long URL</label>
     <!--
@@ -83,7 +84,8 @@
             <span class="icon-sm">C</span><span class="text-label">Customize</span>
           </button>
           <form method="post" action="{{ url_for('delete_link', link_id=link.id) }}">
-            {{ csrf_token() }}
+            <!-- CSRF token for the delete request -->
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this link and all visit records? This cannot be undone.');">
               <span class="icon-sm">X</span><span class="text-label">Delete</span>
             </button>
@@ -93,7 +95,8 @@
     </div>
     <div class="collapse mt-2" id="c{{ link.id }}">
       <form method="post" action="{{ url_for('customize_link', link_id=link.id) }}" enctype="multipart/form-data" class="row g-2">
-          {{ csrf_token() }}
+          <!-- Token ensures only this user may submit modifications -->
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <div class="col-md-3">
             <label class="form-label">Apply Theme</label>
             <select name="theme_id" class="form-select" {% if not can_colors and not can_styles %}disabled{% endif %}>

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -2,7 +2,8 @@
 {% block content %}
 <h2>Forgot Password</h2>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- CSRF token ensures the reset form is submitted by the user -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="email" class="form-label">Email</label>
     <input type="email" class="form-control" id="email" name="email" required>

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,7 +2,8 @@
 {% block content %}
 <h2>Login</h2>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- Include CSRF token to validate login submissions -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="email" class="form-label">Email</label>
     <input type="text" class="form-control" id="email" name="email" required>

--- a/templates/register.html
+++ b/templates/register.html
@@ -2,7 +2,8 @@
 {% block content %}
 <h2>Register</h2>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- CSRF token protects the registration form -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="username" class="form-label">Username</label>
     <input type="text" class="form-control" id="username" name="username" required>

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -2,7 +2,8 @@
 {% block content %}
 <h2>Reset Password</h2>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- Include CSRF token to verify reset request -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="password" class="form-label">New Password</label>
     <input type="password" class="form-control" id="password" name="password" required>

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -3,7 +3,8 @@
 <h2>Confirm Subscription</h2>
 <p>Click confirm to upgrade your account to Pro. No payment is required at this time.</p>
 <form method="post">
-  {{ csrf_token() }}
+  <!-- CSRF token for subscription confirmation -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <button type="submit" class="btn btn-success">Confirm Upgrade</button>
 </form>
 {% endblock %}

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -6,7 +6,8 @@
 </div>
 {% for t in themes %}
 <form method="post" class="row g-2 align-items-end mb-3">
-  {{ csrf_token() }}
+  <!-- Add CSRF token for theme update form -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <input type="hidden" name="theme_id" value="{{ t.id }}">
   <div class="col-md-2">
     <input type="text" class="form-control" name="name" value="{{ t.name }}" required>
@@ -67,7 +68,8 @@
 {% endfor %}
 {% if can_add %}
 <form method="post" class="row g-2 align-items-end">
-  {{ csrf_token() }}
+  <!-- Token prevents CSRF in theme creation form -->
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="col-md-2">
     <input type="text" class="form-control" name="name" placeholder="Theme name" required>
   </div>


### PR DESCRIPTION
## Summary
- hide CSRF tokens by rendering them as hidden inputs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68861020c4f88328ab41f3eecc0d275f