### PR TITLE
Remove outdated freebies feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ QRickLinks is a Flask application that combines a traditional URL shortener with
 - Thumbnail previews of destination pages via the thum.io service
 - Password reset flow that prints reset links to the console
 - Admin interface for managing users, site settings and subscription tiers
-- Subscription system with free and paid tiers, including monthly "freebie" allowances
+- Subscription system with free and paid tiers
 
 ## Installation
 
@@ -65,7 +65,7 @@ Both resolve to the same destination URL.  The QR code image is generated with `
 
 Every visit increments the counter on the associated link and records basic metadata.  The application attempts to resolve the visitor's MAC address from the ARP cache when running on a local network.
 
-Free accounts have monthly quotas for link creation and advanced QR features.  These limits refresh automatically and a small number of "freebies" allow occasional usage beyond the free tier.  Paid tiers remove or increase these limits and can be managed from the admin interface.
+Free accounts have monthly quotas for link creation and advanced QR features.  Paid tiers remove or increase these limits and can be managed from the admin interface.
 
 ## Notes
 

--- a/templates/account.html
+++ b/templates/account.html
@@ -25,7 +25,6 @@
     {% for feat, remaining in quotas.items() %}
     <tr><td>{{ feat.replace('_',' ').title() }}</td><td>{{ remaining }}</td></tr>
     {% endfor %}
-    <tr><td>Freebies</td><td>{{ current_user.freebies_remaining }}</td></tr>
   </tbody>
 </table>
 <h3>Billing Information</h3>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,11 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-{#
-  Removed the freebies reminder from the top of the dashboard. The
-  user request was to hide the "Freebies remaining" banner. Existing
-  template logic remains unchanged except for the omission of this
-  notice.
-#}
 <h2>Create new link</h2>
 <form method="post" action="{{ url_for('create_link') }}">
   <!-- Hidden CSRF field prevents form tampering -->

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Colour Themes</h2>
-<div class="mb-3">
-  <p>Freebies remaining: {{ current_user.freebies_remaining }} (resets {{ current_user.freebies_reset.strftime('%Y-%m-%d') }})</p>
-</div>
 {% for t in themes %}
 <form method="post" class="row g-2 align-items-end mb-3">
   <!-- Add CSRF token for theme update form -->


### PR DESCRIPTION
## Summary
- drop references to freebies in documentation and templates
- remove freebies columns and related logic from `app.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688612ecade8832892579ff5e097d1fb