### PR TITLE
Switch to email-based login

### DIFF
--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -14,7 +14,7 @@
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ url_for('admin_dashboard') }}">Admin Dashboard</a>
     <div class="d-flex">
-      <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>
+      <span class="navbar-text me-2">Logged in as {{ current_user.email }}</span>
       <a class="btn btn-outline-secondary" href="{{ url_for('admin_logout') }}">Logout</a>
     </div>
   </div>

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -5,8 +5,8 @@
   <!-- CSRF token prevents cross-site attacks -->
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
-    <label for="username" class="form-label">Username</label>
-    <input type="text" class="form-control" id="username" name="username" required>
+    <label for="email" class="form-label">Email</label>
+    <input type="email" class="form-control" id="email" name="email" required>
   </div>
   <div class="mb-3">
     <label for="password" class="form-label">Password</label>

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -4,7 +4,7 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th>Username</th>
+      <th>Email</th>
       <th>Tier</th>
       <th>Links</th>
       <th>Total Clicks</th>
@@ -14,7 +14,7 @@
   <tbody>
     {% for row in users %}
     <tr>
-      <td>{{ row.user.username }}</td>
+      <td>{{ row.user.email }}</td>
       <td>{{ row.user.tier.name if row.user.tier else 'Free' }}</td>
       <td>{{ row.link_count }}</td>
       <td>{{ row.total_clicks }}</td>

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,7 +30,7 @@
     </div>
     <div class="d-flex">
       {% if current_user.is_authenticated %}
-      <span class="navbar-text me-2">Logged in as {{ current_user.username }}</span>
+      <span class="navbar-text me-2">Logged in as {{ current_user.email }}</span>
       <a class="btn btn-outline-secondary" href="{{ url_for('logout') }}">Logout</a>
       {% else %}
       <a class="btn btn-outline-primary me-2" href="{{ url_for('login') }}">Login</a>

--- a/templates/register.html
+++ b/templates/register.html
@@ -5,10 +5,6 @@
   <!-- CSRF token protects the registration form -->
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
-    <label for="username" class="form-label">Username</label>
-    <input type="text" class="form-control" id="username" name="username" required>
-  </div>
-  <div class="mb-3">
     <label for="email" class="form-label">Email</label>
     <input type="email" class="form-control" id="email" name="email" required>
   </div>


### PR DESCRIPTION
## Summary
- remove username field from templates
- store email in both `email` and `username` columns for compatibility
- authenticate users and admins by email only
- show email instead of username across the UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688619b460b08328af89d8b34f1b0985