### PR TITLE
Implement forgotten password email support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ QRickLinks is a Flask application that combines a traditional URL shortener with
 - Dashboard showing existing links, usage quotas and visit counts
 - Basic analytics that record IP address, MAC address (when available) and referrer
 - Thumbnail previews of destination pages via the thum.io service
-- Password reset flow that prints reset links to the console
+- Password reset flow with optional email delivery
 - Admin interface for managing users, site settings and subscription tiers
 - Subscription system with free and paid tiers
 
@@ -83,6 +83,16 @@ The initial database seed creates an administrator user so you can immediately a
 * Password: `Admin12345`
 
 Log in at `http://localhost:5000/admin/login` to adjust global settings such as the base URL used when generating short links.
+
+### Password reset emails
+
+Admins can configure an SMTP server so users receive password reset links via
+email. Navigate to **Admin &gt; Password Reset** and enter your server details.
+Leave the server field blank to disable email delivery. When no server is
+configured the reset link will be printed to the console.
+
+You can specify the server address, port, credentials, whether TLS should be
+used, the "from" address and how long reset tokens remain valid.
 
 ## How it works
 

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -26,6 +26,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_dashboard') }}">Dashboard</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_users') }}">Users</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_settings') }}">Settings</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_password_settings') }}">Password Reset</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_tiers') }}">Pricing Tiers</a></li>
       </ul>
     </nav>

--- a/templates/admin_password_settings.html
+++ b/templates/admin_password_settings.html
@@ -1,0 +1,37 @@
+{% extends 'admin_base.html' %}
+{% block content %}
+<h2>Password Reset Configuration</h2>
+<p class="text-muted">Set up email details for sending password reset links. Leave the server blank to output links to the console instead.</p>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <div class="mb-3">
+    <label for="smtp_server" class="form-label">SMTP Server</label>
+    <input type="text" class="form-control" id="smtp_server" name="smtp_server" value="{{ settings.smtp_server }}">
+  </div>
+  <div class="mb-3">
+    <label for="smtp_port" class="form-label">SMTP Port</label>
+    <input type="number" class="form-control" id="smtp_port" name="smtp_port" value="{{ settings.smtp_port }}">
+  </div>
+  <div class="mb-3">
+    <label for="smtp_username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="smtp_username" name="smtp_username" value="{{ settings.smtp_username }}">
+  </div>
+  <div class="mb-3">
+    <label for="smtp_password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="smtp_password" name="smtp_password" value="{{ settings.smtp_password }}">
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="smtp_use_tls" name="smtp_use_tls" {% if settings.smtp_use_tls %}checked{% endif %}>
+    <label class="form-check-label" for="smtp_use_tls">Use TLS</label>
+  </div>
+  <div class="mb-3">
+    <label for="smtp_sender" class="form-label">Sender Address</label>
+    <input type="email" class="form-control" id="smtp_sender" name="smtp_sender" value="{{ settings.smtp_sender }}">
+  </div>
+  <div class="mb-3">
+    <label for="reset_token_hours" class="form-label">Token Expiry (hours)</label>
+    <input type="number" class="form-control" id="reset_token_hours" name="reset_token_hours" value="{{ settings.reset_token_hours }}" min="1">
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support password reset via email with SMTP
- expose email configuration in admin UI
- store SMTP and token settings in database
- document password reset configuration

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68861cf0f99883288581d827e442272c