### PR TITLE
Add admin test email feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,17 @@ Leave the server field blank to disable email delivery. When no server is
 configured the reset link will be printed to the console.
 
 You can specify the server address, port, credentials, whether TLS should be
-used, the "from" address and how long reset tokens remain valid.
+used, the "from" address and how long reset tokens remain valid. After saving
+your settings you can send a test message from the same page to verify that
+delivery works.
+
+#### Example SMTP settings
+
+* **Gmail** – Server: `smtp.gmail.com`, Port: `587`, TLS enabled. Use an
+  application password if two-factor authentication is enabled or allow less
+  secure app access.
+* **GoDaddy** – Server: `smtpout.secureserver.net`, Port: `587`, TLS enabled.
+  Use your GoDaddy email address and password as the credentials.
 
 ## How it works
 

--- a/templates/admin_password_settings.html
+++ b/templates/admin_password_settings.html
@@ -34,4 +34,15 @@
   </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
+
+<h3 class="mt-5">Send Test Email</h3>
+<p class="text-muted">Use this form to verify that your SMTP details work correctly.</p>
+<form method="post" action="{{ url_for('admin_test_email') }}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <div class="mb-3">
+    <label for="test_email" class="form-label">Recipient Address</label>
+    <input type="email" class="form-control" id="test_email" name="test_email" required>
+  </div>
+  <button type="submit" class="btn btn-secondary">Send Test Email</button>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow admins to send a test email from the password settings page
- document gmail and GoDaddy SMTP instructions

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68861fe8b6cc8328a7f6f751db0d50c4