### PR TITLE
Fix IP geolocation fetch

### DIFF
--- a/templates/link_details.html
+++ b/templates/link_details.html
@@ -42,10 +42,11 @@
   #}
   const ips = {{ visit_map.keys()|map(attribute=0)|list|tojson }};
   ips.forEach(ip => {
-    fetch('http://ip-api.com/json/' + ip)
+    // Use HTTPS to avoid mixed content warnings when the site runs over HTTPS
+    fetch('https://ip-api.com/json/' + ip)
       .then(r => r.json())
       .then(d => {
-        if(d.status === 'success'){
+        if (d.status === 'success') {
           L.marker([d.lat, d.lon]).addTo(map).bindPopup(ip);
         }
       });


### PR DESCRIPTION
## Summary
- ensure Leaflet map uses HTTPS for IP address lookups

## Testing
- `python -m py_compile app.py`
- `python -m py_compile rpi_qrlinks.py run_windows.py`
- `flake8` *(fails: various style errors in app.py)*

------
https://chatgpt.com/codex/tasks/task_e_68865401cb508328931c163a9f9dec10