### PR TITLE
Add QR code formats with quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ QRickLinks is a Flask application that combines a traditional URL shortener with
 - User registration and email/password or Google OAuth login
 - Random `adjective.adjective.noun` slug generation alongside a base62 short code
 - Automatic QR code creation for every link with extensive customisation options
+  including multiple module patterns such as rounded, gapped and bar styles
 - Dashboard showing existing links, usage quotas and visit counts
 - Basic analytics that record IP address, MAC address (when available) and referrer
 - Thumbnail previews of destination pages via the thum.io service

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -27,6 +27,10 @@
     <input type="number" class="form-control" id="advanced_styles_limit" name="advanced_styles_limit" value="{{ settings.advanced_styles_limit }}" min="0">
   </div>
   <div class="mb-3">
+    <label for="code_formats_limit" class="form-label">Code Formats</label>
+    <input type="number" class="form-control" id="code_formats_limit" name="code_formats_limit" value="{{ settings.code_formats_limit }}" min="0">
+  </div>
+  <div class="mb-3">
     <label for="logo_embedding_limit" class="form-label">Logo Embedding</label>
     <input type="number" class="form-control" id="logo_embedding_limit" name="logo_embedding_limit" value="{{ settings.logo_embedding_limit }}" min="0">
   </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -138,6 +138,9 @@
               <option value="square" {% if link.pattern == 'square' %}selected{% endif %}>Square</option>
               <option value="rounded" {% if link.pattern == 'rounded' %}selected{% endif %}>Rounded</option>
               <option value="circle" {% if link.pattern == 'circle' %}selected{% endif %}>Circle</option>
+              <option value="gapped" {% if link.pattern == 'gapped' %}selected{% endif %}>Gapped</option>
+              <option value="bars-horizontal" {% if link.pattern == 'bars-horizontal' %}selected{% endif %}>Horizontal Bars</option>
+              <option value="bars-vertical" {% if link.pattern == 'bars-vertical' %}selected{% endif %}>Vertical Bars</option>
             </select>
           </div>
           <div class="col-md-2">

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -42,6 +42,9 @@
       <option value="square" {% if t.pattern=='square' %}selected{% endif %}>Square</option>
       <option value="rounded" {% if t.pattern=='rounded' %}selected{% endif %}>Rounded</option>
       <option value="circle" {% if t.pattern=='circle' %}selected{% endif %}>Circle</option>
+      <option value="gapped" {% if t.pattern=='gapped' %}selected{% endif %}>Gapped</option>
+      <option value="bars-horizontal" {% if t.pattern=='bars-horizontal' %}selected{% endif %}>Horizontal Bars</option>
+      <option value="bars-vertical" {% if t.pattern=='bars-vertical' %}selected{% endif %}>Vertical Bars</option>
     </select>
   </div>
   <div class="col-md-1">
@@ -103,6 +106,9 @@
       <option value="square">Square</option>
       <option value="rounded">Rounded</option>
       <option value="circle">Circle</option>
+      <option value="gapped">Gapped</option>
+      <option value="bars-horizontal">Horizontal Bars</option>
+      <option value="bars-vertical">Vertical Bars</option>
     </select>
   </div>
   <div class="col-md-1">


### PR DESCRIPTION
## Summary
- introduce new "code formats" feature with quota and usage tracking
- support additional QR module patterns (gapped and bar styles)
- expose code formats in admin settings and tier management
- allow users to select new patterns when customising QR codes
- document new patterns in the README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6886625c9e7c83289d55ae8f81e74063