### PR TITLE
Add advanced barcode selection

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -144,6 +144,14 @@
             </select>
           </div>
           <div class="col-md-2">
+            <label for="barcode_type{{ link.id }}" class="form-label">Advanced</label>
+            <select id="barcode_type{{ link.id }}" name="barcode_type" class="form-select" {% if not can_styles %}disabled{% endif %}>
+              {% for val, label in barcode_types.items() %}
+              <option value="{{ val }}" {% if link.barcode_type == val %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="col-md-2">
             <label for="error_correction{{ link.id }}" class="form-label">Redundancy</label>
             <select id="error_correction{{ link.id }}" name="error_correction" class="form-select" {% if not can_styles %}disabled{% endif %}>
               <option value="L" {% if link.error_correction == 'L' %}selected{% endif %}>L</option>

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -47,6 +47,13 @@
       <option value="bars-vertical" {% if t.pattern=='bars-vertical' %}selected{% endif %}>Vertical Bars</option>
     </select>
   </div>
+  <div class="col-md-2">
+    <select name="barcode_type" class="form-select">
+      {% for val, label in barcode_types.items() %}
+      <option value="{{ val }}" {% if t.barcode_type==val %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
   <div class="col-md-1">
     <select name="error_correction" class="form-select">
       <option value="L" {% if t.error_correction=='L' %}selected{% endif %}>L</option>
@@ -109,6 +116,13 @@
       <option value="gapped">Gapped</option>
       <option value="bars-horizontal">Horizontal Bars</option>
       <option value="bars-vertical">Vertical Bars</option>
+    </select>
+  </div>
+  <div class="col-md-2">
+    <select name="barcode_type" class="form-select">
+      {% for val, label in barcode_types.items() %}
+      <option value="{{ val }}">{{ label }}</option>
+      {% endfor %}
     </select>
   </div>
   <div class="col-md-1">


### PR DESCRIPTION
## Summary
- add `barcode_type` field to `Link` and `ColourTheme`
- support advanced barcode types (GS1 DataMatrix, GS1 Digital Link, PDF417, Aztec Code, GS1 DataBar, MaxiCode)
- expose new option in link customisation and colour theme forms

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6886765fb2d883288b3fc03bbf60d27f