### PR TITLE
Add advanced formats feature to subscription tiers

### DIFF
--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -31,6 +31,10 @@
     <input type="number" class="form-control" id="code_formats_limit" name="code_formats_limit" value="{{ settings.code_formats_limit }}" min="0">
   </div>
   <div class="mb-3">
+    <label for="advanced_formats_limit" class="form-label">Advanced Formats</label>
+    <input type="number" class="form-control" id="advanced_formats_limit" name="advanced_formats_limit" value="{{ settings.advanced_formats_limit }}" min="0">
+  </div>
+  <div class="mb-3">
     <label for="logo_embedding_limit" class="form-label">Logo Embedding</label>
     <input type="number" class="form-control" id="logo_embedding_limit" name="logo_embedding_limit" value="{{ settings.logo_embedding_limit }}" min="0">
   </div>


### PR DESCRIPTION
## Summary
- add `advanced_formats` support across models and feature mappings
- handle advanced format quotas during link creation and update
- expose advanced format limits in admin settings
- include advanced format columns when managing subscription tiers

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688679395fe08328a6ed0e18e916398f