### PR TITLE
Fix internal server error caused by missing database

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ QRickLinks is a Flask application that combines a traditional URL shortener with
    python app.py
    ```
    The database is created automatically on first run and minimal default data is inserted.
+   Alternatively you can run the app with `flask run` and the tables will be
+   created when the application first receives a request.
 5. Visit `http://localhost:5000` to register an account and start creating links.
 
 ### Google OAuth configuration

--- a/app.py
+++ b/app.py
@@ -1772,8 +1772,13 @@ def initialize_database() -> None:
                 SubscriptionTier(name='Basic', monthly_price=5.0, yearly_price=50.0, links_unlimited=True, custom_colors_unlimited=True, advanced_styles_unlimited=True, code_formats_unlimited=True, advanced_formats_unlimited=True, logo_embedding_unlimited=True, analytics_unlimited=True, custom_slugs_unlimited=True, full_palette=False, colour_themes_limit=3),
                 SubscriptionTier(name='Pro', monthly_price=10.0, yearly_price=100.0, links_unlimited=True, custom_colors_unlimited=True, advanced_styles_unlimited=True, code_formats_unlimited=True, advanced_formats_unlimited=True, logo_embedding_unlimited=True, analytics_unlimited=True, custom_slugs_unlimited=True, full_palette=True, colour_themes_unlimited=True),
             ])
-            db.session.commit()
+        db.session.commit()
 
+
+# Running ``flask run`` imports the app without executing the ``__main__``
+# block. Call ``initialize_database`` here so the database is prepared
+# regardless of how the server is launched.
+initialize_database()
 
 if __name__ == '__main__':
     # Prepare the database and default records before starting


### PR DESCRIPTION
## Summary
- initialise the database when `app.py` is imported so using `flask run` works
- clarify in README that `flask run` will also create the database on first request

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688722737f5883288cb55f20f23b1723