### PR TITLE
Fix run_server on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Start the server with:
 ./run_server.sh [-p PORT] [--development]
 ```
 
+The script now creates a Python virtual environment on first run if one is not
+present, so running it directly is enough to install all requirements.
+
 Omitting `--development` runs a production Waitress server.
 
 Make sure the selected `PORT` is accessible externally. Open the port in the

--- a/run_server.sh
+++ b/run_server.sh
@@ -28,7 +28,24 @@ done
 
 # Load environment variables if present
 if [ -f env.sh ]; then
+    # shellcheck disable=SC1091  # env.sh is user generated
     source env.sh
+fi
+
+# ---------------------------------------------------------------------------
+# Ensure a virtual environment exists so dependencies are isolated. This keeps
+# the script self-contained and avoids requiring the separate setup script on
+# first run.
+# ---------------------------------------------------------------------------
+if [ ! -f "venv/bin/activate" ]; then
+    echo "Creating Python virtual environment and installing dependencies..."
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install --upgrade pip
+    pip install -r requirements.txt
+else
+    # Activate the existing environment
+    source venv/bin/activate
 fi
 
 # Allow incoming traffic on the chosen port when a firewall is active. This
@@ -38,9 +55,6 @@ if command -v ufw >/dev/null 2>&1 && sudo ufw status | grep -q "Status: active";
 elif command -v firewall-cmd >/dev/null 2>&1 && sudo firewall-cmd --state >/dev/null 2>&1; then
     sudo firewall-cmd --permanent --add-port="${PORT}/tcp" && sudo firewall-cmd --reload
 fi
-
-# Activate the virtual environment
-source venv/bin/activate
 
 # Ensure the database schema is ready before starting
 python - <<PY


### PR DESCRIPTION
## Summary
- improve run_server.sh to set up a virtual environment if missing
- document automatic setup in the README

## Testing
- `python -m py_compile app.py rpi_qrlinks.py run_windows.py`

------
https://chatgpt.com/codex/tasks/task_e_688940864f5483289542734c81efafcf