### PR TITLE
Add link diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ QRickLinks is a Flask application that combines a traditional URL shortener with
 - Automatic QR code creation for every link with extensive customisation options
   including multiple module patterns such as rounded, gapped and bar styles
 - Dashboard showing existing links, usage quotas and visit counts
+- Built-in diagnostics check if target sites are reachable and display a
+  traffic light status next to each entry with optional one-click fixes
 - Basic analytics that record IP address, MAC address (when available) and referrer
 - Thumbnail previews of destination pages via the thum.io service
 - Password reset flow with optional email delivery
@@ -144,6 +146,12 @@ When a user creates a link, two identifiers are generated:
 Both resolve to the same destination URL.  The QR code image is generated with `qrcode` and stored in `static/qr/`.  Customisation options (colours, module style, error correction level and optional logo) are persisted so the code can be recreated later or downloaded as SVG.
 
 Every visit increments the counter on the associated link and records basic metadata.  The application attempts to resolve the visitor's MAC address from the ARP cache when running on a local network.
+
+The dashboard can run a quick availability test on each destination URL. A
+small traffic light indicator shows green when the site responds, amber for
+client errors and red for server errors or connection failures. When a link
+fails the test QRickLinks offers to automatically switch between `http` and
+`https`.
 
 Free accounts have monthly quotas for link creation and advanced QR features.  Paid tiers remove or increase these limits and can be managed from the admin interface.
 

--- a/static/style.css
+++ b/static/style.css
@@ -51,3 +51,15 @@ body {
   border-color: #ffc107;    /* match Bootstrap warning hue */
 }
 
+/* Small coloured circles used to display link availability */
+.status-indicator {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+.status-ok { background-color: #28a745; }
+.status-warn { background-color: #ffc107; }
+.status-error { background-color: #dc3545; }
+.status-unknown { background-color: #6c757d; }
+

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -39,7 +39,9 @@
 </form>
 
 <hr>
-<h2>Your links</h2>
+<h2 class="d-flex align-items-center">Your links
+  <button class="btn btn-sm btn-outline-secondary ms-auto" onclick="checkAll()">Run Diagnostics</button>
+</h2>
 {#
   Each link is displayed as a Bootstrap card instead of a wide table row so the
   three URL variants stack vertically on mobile devices. The card layout also
@@ -50,7 +52,10 @@
   <div class="card-body">
     <div class="d-md-flex justify-content-between align-items-start">
       <div class="mb-2">
-        <div><a href="{{ link.short_url }}" target="_blank">{{ link.slug }}</a></div>
+        <div>
+          <a href="{{ link.short_url }}" target="_blank">{{ link.slug }}</a>
+          <span class="status-indicator status-unknown ms-1" id="status-{{ link.id }}" data-link="{{ link.id }}"></span>
+        </div>
         <div><a href="{{ link.code_url }}" target="_blank">{{ link.short_code }}</a></div>
         <div><a href="{{ link.original_url }}" target="_blank">{{ link.original_url }}</a></div>
       </div>
@@ -76,6 +81,9 @@
           </a>
           <button class="btn btn-sm btn-outline-primary mb-1" type="button" data-bs-toggle="collapse" data-bs-target="#c{{ link.id }}" aria-expanded="false" aria-controls="c{{ link.id }}">
             <span class="icon-sm">C</span><span class="text-label">Customize</span>
+          </button>
+          <button class="btn btn-sm btn-warning mb-1" type="button" onclick="checkLink({{ link.id }})">
+            <span class="icon-sm">?</span><span class="text-label">Check</span>
           </button>
           <form method="post" action="{{ url_for('delete_link', link_id=link.id) }}">
             <!-- CSRF token for the delete request -->
@@ -172,4 +180,36 @@
   </div>
 </div>
 {% endfor %}
+<script>
+function updateStatus(id, status) {
+  const el = document.getElementById('status-' + id);
+  el.className = 'status-indicator status-' + status + ' ms-1';
+}
+
+function checkLink(id) {
+  fetch('/check_site/' + id)
+    .then(r => r.json())
+    .then(data => {
+      updateStatus(id, data.status);
+      if (data.status !== 'ok') {
+        const msg = data.message + '\nAttempt automatic fix?';
+        if (confirm(msg)) {
+          fetch('/check_site/' + id + '?fix=1')
+            .then(r => r.json())
+            .then(res => {
+              updateStatus(id, res.status);
+              alert(res.message);
+            });
+        }
+      }
+    });
+}
+
+function checkAll() {
+  document.querySelectorAll('.status-indicator').forEach(el => {
+    const id = el.dataset.link;
+    if (id) checkLink(id);
+  });
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow users to verify each destination URL
- show a traffic‑light indicator next to each link
- automatically try to fix failing links by switching scheme
- document the diagnostics feature

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688c74ad02788328a4b080148829e7df