### PR TITLE
Add profile menu and screens with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,32 @@ QRickLinks is a Flask application that combines a traditional URL shortener with
 
 ## Installation
 
-1. Install the Python dependencies:
+1. Create and activate a virtual environment so dependencies stay isolated:
+   - **Linux/macOS**
+     ```bash
+     python3 -m venv venv
+     source venv/bin/activate
+     ```
+   - **Windows**
+     ```powershell
+     py -m venv venv
+     .\venv\Scripts\activate
+     ```
+2. Install the Python dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-2. (Optional) export a `SECRET_KEY` so session cookies are signed with your own value:
+3. (Optional) export a `SECRET_KEY` so session cookies are signed with your own value:
    ```bash
    export SECRET_KEY="your-secret-key"
    ```
-3. (Optional) configure Google OAuth by setting `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` in the environment. See the detailed instructions in the next section.
-4. Run the development server:
+4. (Optional) configure Google OAuth by setting `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` in the environment. See the detailed instructions in the next section.
+5. Run the development server:
    ```bash
-   python app.py
+   python qricklinks_app.py
    ```
-   The database is created automatically on first run and minimal default data is inserted.
-   Alternatively you can run the app with `flask run` and the tables will be
-   created when the application first receives a request.
-5. Visit `http://localhost:5000` to register an account and start creating links.
+   The database is created automatically on first run and minimal default data is inserted. Alternatively you can run the app with `flask run` and the tables will be created when the application first receives a request.
+6. Visit `http://localhost:5000` to register an account and start creating links.
 
 ### Google OAuth configuration
 

--- a/qricklinks_app.py
+++ b/qricklinks_app.py
@@ -40,6 +40,7 @@ from qrcode.image.styles.moduledrawers import svg as svg_drawers
 import io
 from qrcode.image.styles.colormasks import SolidFillColorMask
 from PIL import ImageColor
+import logging
 
 # Initialize Flask app and database
 app = Flask(__name__)
@@ -48,6 +49,11 @@ app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'change-this-secret-key')
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///qricklinks.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+# Configure basic logging so debugging information is printed to the
+# terminal. The log level can be adjusted via the ``QRICKLINKS_LOG_LEVEL``
+# environment variable to aid troubleshooting in production.
+logging.basicConfig(level=os.environ.get("QRICKLINKS_LOG_LEVEL", "INFO"))
 
 db = SQLAlchemy(app)
 # Enable CSRF protection for all POST forms using Flask-WTF
@@ -1033,6 +1039,54 @@ def user_settings():
         limited_palette=LIMITED_PALETTE,
         barcode_types=BARCODE_TYPES,
     )
+
+
+# ----------------------------
+# Profile Menu Routes
+# ----------------------------
+
+
+@app.route('/manage_profiles')
+@login_required
+def manage_profiles() -> str:
+    """Allow the user to manage additional profiles."""
+    app.logger.info("Manage Profiles accessed by %s", current_user.email)
+    return render_template('manage_profiles.html')
+
+
+@app.route('/learning_zone')
+@login_required
+def learning_zone() -> str:
+    """Educational resources for using QRickLinks."""
+    app.logger.info("Learning Zone accessed by %s", current_user.email)
+    return render_template('learning_zone.html')
+
+
+@app.route('/my_details')
+@login_required
+def my_details() -> str:
+    """Display or update the current user's details."""
+    app.logger.info("My Details accessed by %s", current_user.email)
+    return render_template('my_details.html')
+
+
+@app.route('/subscription_details')
+@login_required
+def subscription_details() -> str:
+    """Show information about the user's subscription."""
+    app.logger.info("Subscription Details accessed by %s", current_user.email)
+    return render_template('subscription_details.html')
+
+
+@app.route('/manage_users')
+@login_required
+def manage_users() -> str:
+    """Administrative interface for managing users."""
+    if not current_user.is_admin:
+        app.logger.warning("Unauthorized Manage Users access by %s", current_user.email)
+        abort(403)
+    app.logger.info("Manage Users accessed by %s", current_user.email)
+    return render_template('manage_users.html')
 
 
 # ----------------------------

--- a/rpi_qrlinks.py
+++ b/rpi_qrlinks.py
@@ -14,9 +14,12 @@ Omitting ``port`` defaults to ``5000``.
 
 import argparse
 
-# Import the Flask application instance from app.py
-# Import the Flask app and database initialization helper
-from app import app, initialize_database, get_settings
+# Import the Flask application instance from the dedicated module
+# ``qricklinks_app`` along with helpers for setting up the database and
+# reading configuration. Using a descriptive module name makes it clear which
+# project the application belongs to and aids debugging when multiple Flask
+# apps are installed on the same system.
+from qricklinks_app import app, initialize_database, get_settings
 import socket
 
 try:
@@ -53,7 +56,7 @@ def main() -> None:
     # the network.  ``socket`` is used to detect the local IP address without
     # making an external request.  The resulting URL includes the chosen port
     # so it matches the running server.
-    from app import db
+    from qricklinks_app import db
     with app.app_context():
         settings = get_settings()
         try:

--- a/run_server.sh
+++ b/run_server.sh
@@ -58,7 +58,8 @@ fi
 
 # Ensure the database schema is ready before starting
 python - <<PY
-from app import initialize_database
+# Import the database initialisation helper from the project-specific module
+from qricklinks_app import initialize_database
 initialize_database()
 PY
 

--- a/run_windows.py
+++ b/run_windows.py
@@ -31,7 +31,9 @@ def main() -> None:
     subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
 
     # Import the Flask application only after dependencies are available
-    from app import app, initialize_database
+    # Import the Flask app and database setup helper from the descriptive
+    # ``qricklinks_app`` module so the name clearly reflects the project.
+    from qricklinks_app import app, initialize_database
 
     # Perform database migrations and insert default records
     initialize_database()

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,7 @@
     #}
     <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/lux/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     {# Custom styles for layout tweaks and additional theming #}
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
@@ -24,14 +25,25 @@
       {% else %}
       <a class="nav-link text-white" href="{{ url_for('pricing') }}">Pricing</a>
       {% endif %}
-      {% if current_user.is_authenticated %}
-      <a class="nav-link text-white" href="{{ url_for('account') }}">My Account</a>
-      {% endif %}
     </div>
-    <div class="d-flex">
+    <div class="d-flex align-items-center">
       {% if current_user.is_authenticated %}
-      <span class="navbar-text me-2">Logged in as {{ current_user.email }}</span>
-      <a class="btn btn-outline-secondary" href="{{ url_for('logout') }}">Logout</a>
+      <div class="dropdown">
+        <a href="#" class="d-flex align-items-center text-white text-decoration-none dropdown-toggle" id="profileDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="bi bi-person-circle fs-3"></i>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end text-small" aria-labelledby="profileDropdown">
+          <li><a class="dropdown-item" href="{{ url_for('manage_profiles') }}">Manage Profiles</a></li>
+          <li><a class="dropdown-item" href="{{ url_for('learning_zone') }}">Learning Zone</a></li>
+          <li><a class="dropdown-item" href="{{ url_for('my_details') }}">My Details</a></li>
+          <li><a class="dropdown-item" href="{{ url_for('subscription_details') }}">Subscription Details</a></li>
+          {% if current_user.is_admin %}
+          <li><a class="dropdown-item" href="{{ url_for('manage_users') }}">Manage Users</a></li>
+          {% endif %}
+          <li><hr class="dropdown-divider"></li>
+          <li><a class="dropdown-item" href="{{ url_for('logout') }}">Sign out</a></li>
+        </ul>
+      </div>
       {% else %}
       <a class="btn btn-outline-primary me-2" href="{{ url_for('login') }}">Login</a>
       <a class="btn btn-primary" href="{{ url_for('register') }}">Register</a>

--- a/templates/learning_zone.html
+++ b/templates/learning_zone.html
@@ -1,0 +1,6 @@
+{# Template providing resources to help users learn the system #}
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Learning Zone</h1>
+<p>Welcome to the Learning Zone. Here you will find tutorials and tips to get the most from QRickLinks.</p>
+{% endblock %}

--- a/templates/manage_profiles.html
+++ b/templates/manage_profiles.html
@@ -1,0 +1,9 @@
+{#
+  Template: manage_profiles.html
+  Purpose: placeholder page allowing users to manage multiple profiles.
+#}
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Manage Profiles</h1>
+<p>Use this screen to create or switch between different user profiles. This placeholder page will be expanded with full profile management tools.</p>
+{% endblock %}

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -1,0 +1,6 @@
+{# Template for administrators to manage application users #}
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Manage Users</h1>
+<p>This administrative page allows management of user accounts. Only administrators can view this section.</p>
+{% endblock %}

--- a/templates/my_details.html
+++ b/templates/my_details.html
@@ -1,0 +1,6 @@
+{# Template allowing users to view and update their personal details #}
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">My Details</h1>
+<p>Review and update your personal information on this page. Future versions will include editable forms.</p>
+{% endblock %}

--- a/templates/subscription_details.html
+++ b/templates/subscription_details.html
@@ -1,0 +1,6 @@
+{# Template summarising the user's subscription information #}
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-4">Subscription Details</h1>
+<p>View your current plan and renewal information here. Additional subscription management tools will appear in future updates.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- rename main Flask app to `qricklinks_app` and enable basic logging for easier debugging
- add profile icon dropdown in navbar with links to profile management, learning resources, personal details, subscription info and admin user management
- create placeholder templates and routes for new profile menu pages and update setup instructions

## Testing
- `python -m py_compile qricklinks_app.py rpi_qrlinks.py run_windows.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892148ff8688328beb7f76097125d4c